### PR TITLE
Hint system (Plan 1): 3-tier 弱/中/强 with stamina cost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ ssl/nginx.crt
 ssl/nginx.key
 .vscode/settings.json
 .spec-workflow/session.json
+.worktrees/

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -735,23 +735,24 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
 
         // Medium-hint cell overlay (shows where a block should go, no orientation)
         for (var ml in hintState.mediumLocked) {
-          var mlc = hintState.mediumLocked[ml];
-          // The cell (mlc.x, mlc.y) is the block origin. We highlight ONLY the origin cell —
-          // user still doesn't know the shape.
-          if (mlc.x === bx && mlc.y === by) {
-            // Find block color from palette/dropped (each block has a `color` field
-            // from initialBlockTypes; see board.js:15-24)
-            var blkColor = '#888';
-            for (var pp = 0; pp < palette.length; pp++) if (palette[pp].id === ml) blkColor = palette[pp].color || blkColor;
-            for (var dp = 0; dp < dropped.length; dp++) if (dropped[dp].id === ml) blkColor = dropped[dp].color || blkColor;
-            ctx.save();
-            ctx.strokeStyle = blkColor;
-            ctx.lineWidth = 4;
-            ctx.strokeRect(px + 2, py + 2, cs - 4, cs - 4);
-            ctx.fillStyle = blkColor;
-            var d = Math.max(6, Math.floor(cs * 0.18));
-            ctx.fillRect(px + cs / 2 - d / 2, py + cs / 2 - d / 2, d, d);
-            ctx.restore();
+          var cells = hintState.mediumLocked[ml] || [];
+          for (var ci = 0; ci < cells.length; ci++) {
+            var mlc = cells[ci];
+            if (mlc.x === bx && mlc.y === by) {
+              // Find block color from palette/dropped (each block has a `color` field
+              // from initialBlockTypes; see board.js:15-24)
+              var blkColor = '#888';
+              for (var pp = 0; pp < palette.length; pp++) if (palette[pp].id === ml) blkColor = palette[pp].color || blkColor;
+              for (var dp = 0; dp < dropped.length; dp++) if (dropped[dp].id === ml) blkColor = dropped[dp].color || blkColor;
+              ctx.save();
+              ctx.strokeStyle = blkColor;
+              ctx.lineWidth = 4;
+              ctx.strokeRect(px + 2, py + 2, cs - 4, cs - 4);
+              ctx.fillStyle = blkColor;
+              var d = Math.max(6, Math.floor(cs * 0.18));
+              ctx.fillRect(px + cs / 2 - d / 2, py + cs / 2 - d / 2, d, d);
+              ctx.restore();
+            }
           }
         }
 
@@ -880,18 +881,19 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
           var btn = L.hintTierBtns[ti2];
           var used = Hint.countUsed(hintState, btn.tier);
           var cap = Hint.CAPS[btn.tier];
-          var disabled = used >= cap;
+          var disabled = (cap !== undefined) && used >= cap;
           var fill = disabled ? '#eee' : (btn.tier === 'strong' ? '#E53935' : btn.tier === 'medium' ? '#FB8C00' : BRAND);
           R.roundRect(ctx, btn.x, btn.y, btn.w, btn.h, 8, fill);
           R.text(ctx, tierLabels[btn.tier], btn.x + 12, btn.y + 8, 14, disabled ? '#999' : '#fff', 'left');
-          R.text(ctx, costLabels[btn.tier] + '  ' + used + '/' + cap, btn.x + 12, btn.y + 28, 11, disabled ? '#999' : 'rgba(255,255,255,0.85)', 'left');
+          var capStr = (cap !== undefined) ? (used + '/' + cap) : (used + ' 已用');
+          R.text(ctx, costLabels[btn.tier] + '  ' + capStr, btn.x + 12, btn.y + 28, 11, disabled ? '#999' : 'rgba(255,255,255,0.85)', 'left');
         }
       } else {
         R.textBold(ctx, '选择要提示的方块', L.hintPopup.x + L.hintPopup.w / 2, L.hintPopup.y + 18, 17, '#333', 'center');
         for (var hi2 = 0; hi2 < L.hintItems.length; hi2++) {
           var ht = L.hintItems[hi2];
           var alreadyLocked = (hintTier === 'weak' && Hint.isOrientationLocked(hintState, ht.block.id))
-                           || (hintTier === 'medium' && Hint.isCellLocked(hintState, ht.block.id))
+                           || (hintTier === 'medium' && Hint.isMediumExhausted(hintState, ht.block.id, solvedPlacements))
                            || (hintTier === 'strong' && Hint.isFullyLocked(hintState, ht.block.id));
           ctx.globalAlpha = alreadyLocked ? 0.4 : 0.95;
           R.roundRect(ctx, ht.x, ht.y, ht.w, ht.h, 10, ht.block.color);
@@ -1676,27 +1678,8 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
             if (hintTier === 'weak' && Hint.isOrientationLocked(hintState, hBlock.id)) {
               showToast('该方块方向已提示过'); return;
             }
-            if (hintTier === 'medium' && Hint.isCellLocked(hintState, hBlock.id)) {
-              // Already hinted. Check if placed at the solved-target origin.
-              var solvedTarget = solvedPlacements[hBlock.id];
-              var placedAtTarget = false;
-              for (var dpi = 0; dpi < dropped.length; dpi++) {
-                if (dropped[dpi].id === hBlock.id
-                    && dropped[dpi].x === solvedTarget.x
-                    && dropped[dpi].y === solvedTarget.y) {
-                  placedAtTarget = true; break;
-                }
-              }
-              if (placedAtTarget) {
-                showToast('该方块已在提示位置');
-                return;
-              }
-              // Allow free re-show. Hint is already rendered on the board persistently;
-              // just close the popup with a confirmation toast. No stamina, no state change.
-              hintMode = false;
-              hintTier = null;
-              scene.dirty = true;
-              showToast('已提示 ' + hBlock.label + ' 的落点');
+            if (hintTier === 'medium' && Hint.isMediumExhausted(hintState, hBlock.id, solvedPlacements)) {
+              showToast('该方块所有位置已提示完');
               return;
             }
             if (hintTier === 'strong' && Hint.isFullyLocked(hintState, hBlock.id)) {

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -745,8 +745,12 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
             for (var pp = 0; pp < palette.length; pp++) if (palette[pp].id === ml) blkColor = palette[pp].color || blkColor;
             for (var dp = 0; dp < dropped.length; dp++) if (dropped[dp].id === ml) blkColor = dropped[dp].color || blkColor;
             ctx.save();
-            ctx.globalAlpha = 0.35;
-            R.roundRect(ctx, px, py, cs, cs, 4, blkColor);
+            ctx.strokeStyle = blkColor;
+            ctx.lineWidth = 4;
+            ctx.strokeRect(px + 2, py + 2, cs - 4, cs - 4);
+            ctx.fillStyle = blkColor;
+            var d = Math.max(6, Math.floor(cs * 0.18));
+            ctx.fillRect(px + cs / 2 - d / 2, py + cs / 2 - d / 2, d, d);
             ctx.restore();
           }
         }
@@ -1668,6 +1672,17 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
         for (var hi3 = 0; hi3 < L.hintItems.length; hi3++) {
           if (R.hitTest(x, y, L.hintItems[hi3])) {
             var hBlock = L.hintItems[hi3].block;
+            // Per-tier lock check FIRST — don't charge for re-hints
+            if (hintTier === 'weak' && Hint.isOrientationLocked(hintState, hBlock.id)) {
+              showToast('该方块方向已提示过'); return;
+            }
+            if (hintTier === 'medium' && Hint.isCellLocked(hintState, hBlock.id)) {
+              showToast('该方块位置已提示过'); return;
+            }
+            if (hintTier === 'strong' && Hint.isFullyLocked(hintState, hBlock.id)) {
+              showToast('该方块已强提示'); return;
+            }
+            // Now charge stamina and apply
             var blockCost = Hint.COSTS[hintTier];
             if (hintTier === 'weak' && Hint.FIRST_WEAK_FREE && Hint.countUsed(hintState, 'weak') === 0) {
               blockCost = 0;
@@ -1678,15 +1693,12 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
             }
             var res;
             if (hintTier === 'weak') {
-              if (Hint.isOrientationLocked(hintState, hBlock.id)) { showToast('该方块方向已提示过'); return; }
               res = Hint.applyWeak(hintState, hBlock.id, palette, dropped, solvedPlacements);
               showToast('已提示 ' + hBlock.label + ' 的正确方向');
             } else if (hintTier === 'medium') {
-              if (Hint.isCellLocked(hintState, hBlock.id)) { showToast('该方块位置已提示过'); return; }
               res = Hint.applyMedium(hintState, hBlock.id, palette, dropped, solvedPlacements);
               showToast('已提示 ' + hBlock.label + ' 的落点');
             } else {
-              if (Hint.isFullyLocked(hintState, hBlock.id)) { showToast('该方块已强提示'); return; }
               res = Hint.applyStrong(hintState, hBlock.id, palette, dropped, solvedPlacements);
               showToast('已为 ' + hBlock.label + ' 落子');
             }

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -543,7 +543,7 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
     // Hint popup
     if (hintMode) {
       var popW = W * 0.78;
-      var popH = hintTier ? 240 : 290;
+      var popH = 290;
       L.hintPopup = { x: (W - popW) / 2, y: (H - popH) / 2, w: popW, h: popH };
 
       if (!hintTier) {
@@ -1677,7 +1677,27 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
               showToast('该方块方向已提示过'); return;
             }
             if (hintTier === 'medium' && Hint.isCellLocked(hintState, hBlock.id)) {
-              showToast('该方块位置已提示过'); return;
+              // Already hinted. Check if placed at the solved-target origin.
+              var solvedTarget = solvedPlacements[hBlock.id];
+              var placedAtTarget = false;
+              for (var dpi = 0; dpi < dropped.length; dpi++) {
+                if (dropped[dpi].id === hBlock.id
+                    && dropped[dpi].x === solvedTarget.x
+                    && dropped[dpi].y === solvedTarget.y) {
+                  placedAtTarget = true; break;
+                }
+              }
+              if (placedAtTarget) {
+                showToast('该方块已在提示位置');
+                return;
+              }
+              // Allow free re-show. Hint is already rendered on the board persistently;
+              // just close the popup with a confirmation toast. No stamina, no state change.
+              hintMode = false;
+              hintTier = null;
+              scene.dirty = true;
+              showToast('已提示 ' + hBlock.label + ' 的落点');
+              return;
             }
             if (hintTier === 'strong' && Hint.isFullyLocked(hintState, hBlock.id)) {
               showToast('该方块已强提示'); return;

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -1798,7 +1798,7 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
 
     // Control row
     if (L.hintBtn && R.hitTest(x, y, L.hintBtn)) {
-      hintMode = true; scene.dirty = true; return;
+      hintMode = true; hintTier = null; scene.dirty = true; return;
     }
     if (L.resetBtn && R.hitTest(x, y, L.resetBtn)) {
       if (dropped.length === 0) return;

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -7,6 +7,7 @@ var PG = require('./puzzleGenerator');
 var stamina = require('./stamina');
 var shareState = require('./shareState');
 var progress = require('./progress');
+var Hint = require('./hint');
 var initialBlockTypes = B.initialBlockTypes;
 
 var DRAG_THRESHOLD = 8;
@@ -52,7 +53,10 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
   var timer = 0;
   var isWon = false;
   var hintMode = false;
-  var hintedIds = [];
+  var hintState = Hint.createHintState(
+    puzzle.dateStr + ':' + difficulty + ':c' + puzzle.currentComboIndex
+  );
+  var solvedPlacements = PG.solvedPlacements(puzzle.solvedBoard);
   var uncov = B.getUncoverableCells();
   var diffCfg = PG.DIFFICULTY_CONFIG[difficulty];
   var diffLabel = diffCfg.label;
@@ -765,7 +769,7 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
         var item = L.palItems[pi2];
         var isSel = selected && selected.id === item.block.id;
         var isDragOrigin = dragging && dragging.id === item.block.id;
-        var isHinted = hintedIds.indexOf(item.block.id) >= 0;
+        var isHinted = Hint.isOrientationLocked(hintState, item.block.id);
         var bg = isSel ? BRAND_LIGHT : (isHinted ? BRAND_LIGHT : '#fff');
         var border = (isSel || isHinted) ? BRAND : 'rgba(0,0,0,0.12)';
         var scale = isSel ? 1.06 : 1;
@@ -822,7 +826,7 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
       R.textBold(ctx, '选择要提示的方块', L.hintPopup.x + L.hintPopup.w / 2, L.hintPopup.y + 18, 17, '#333', 'center');
       for (var hi2 = 0; hi2 < L.hintItems.length; hi2++) {
         var ht = L.hintItems[hi2];
-        var alreadyHinted = hintedIds.indexOf(ht.block.id) >= 0;
+        var alreadyHinted = Hint.isOrientationLocked(hintState, ht.block.id);
         ctx.globalAlpha = alreadyHinted ? 0.4 : 0.95;
         R.roundRect(ctx, ht.x, ht.y, ht.w, ht.h, 10, ht.block.color);
         if (alreadyHinted) {
@@ -1563,36 +1567,24 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
       for (var hi3 = 0; hi3 < L.hintItems.length; hi3++) {
         if (R.hitTest(x, y, L.hintItems[hi3])) {
           var hBlock = L.hintItems[hi3].block;
-          if (hintedIds.indexOf(hBlock.id) >= 0) return;
-          var hs = PG.getHintShape(puzzle.solvedBoard, hBlock.label);
-          if (!hs) return;
-          for (var pi3 = 0; pi3 < palette.length; pi3++) {
-            if (palette[pi3].id === hBlock.id) palette[pi3].shape = hs;
+          if (Hint.isOrientationLocked(hintState, hBlock.id)) return;
+          var res = Hint.applyWeak(hintState, hBlock.id, palette, dropped, solvedPlacements);
+          hintState = res.newState;
+          palette = res.updatedPalette;
+          dropped = res.updatedDropped;
+          if (selected && selected.id === hBlock.id) {
+            for (var sp2 = 0; sp2 < palette.length; sp2++) {
+              if (palette[sp2].id === hBlock.id) selected.shape = palette[sp2].shape;
+            }
           }
-          if (selected && selected.id === hBlock.id) selected.shape = hs;
-          var placed = null;
-          for (var di = 0; di < dropped.length; di++) {
-            if (dropped[di].id === hBlock.id) { placed = dropped[di]; break; }
-          }
-          if (placed) {
-            dropped = dropped.filter(function (b) { return b.id !== hBlock.id; });
-            var rest = B.cloneBlock(placed);
-            rest.shape = hs; delete rest.x; delete rest.y;
-            palette.push(rest);
-          }
-          hintedIds.push(hBlock.id);
           hintMode = false;
           scene.dirty = true;
           showToast('已提示 ' + hBlock.label + ' 的正确方向');
           return;
         }
       }
-      if (L.hintCloseBtn && R.hitTest(x, y, L.hintCloseBtn)) {
-        hintMode = false; scene.dirty = true; return;
-      }
-      if (L.hintPopup && !R.hitTest(x, y, L.hintPopup)) {
-        hintMode = false; scene.dirty = true; return;
-      }
+      if (L.hintCloseBtn && R.hitTest(x, y, L.hintCloseBtn)) { hintMode = false; scene.dirty = true; return; }
+      if (L.hintPopup && !R.hitTest(x, y, L.hintPopup)) { hintMode = false; scene.dirty = true; return; }
       return;
     }
 
@@ -1670,7 +1662,7 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
     // Preview rotate / flip
     if (L.previewRotateBtn && R.hitTest(x, y, L.previewRotateBtn)) {
       if (selected) {
-        if (hintedIds.indexOf(selected.id) >= 0) { showToast('该方块方向已锁定'); return; }
+        if (Hint.isOrientationLocked(hintState, selected.id)) { showToast('该方块方向已锁定'); return; }
         selected.shape = B.rotateShape(selected.shape);
         for (var rp = 0; rp < palette.length; rp++) {
           if (palette[rp].id === selected.id) palette[rp].shape = selected.shape;
@@ -1681,7 +1673,7 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
     }
     if (L.previewFlipBtn && R.hitTest(x, y, L.previewFlipBtn)) {
       if (selected) {
-        if (hintedIds.indexOf(selected.id) >= 0) { showToast('该方块方向已锁定'); return; }
+        if (Hint.isOrientationLocked(hintState, selected.id)) { showToast('该方块方向已锁定'); return; }
         selected.shape = B.flipShape(selected.shape);
         for (var fp = 0; fp < palette.length; fp++) {
           if (palette[fp].id === selected.id) palette[fp].shape = selected.shape;

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -542,7 +542,8 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
 
     // Hint popup
     if (hintMode) {
-      var popW = W * 0.78, popH = 240;
+      var popW = W * 0.78;
+      var popH = hintTier ? 240 : 290;
       L.hintPopup = { x: (W - popW) / 2, y: (H - popH) / 2, w: popW, h: popH };
 
       if (!hintTier) {
@@ -888,9 +889,20 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
           var alreadyLocked = (hintTier === 'weak' && Hint.isOrientationLocked(hintState, ht.block.id))
                            || (hintTier === 'medium' && Hint.isCellLocked(hintState, ht.block.id))
                            || (hintTier === 'strong' && Hint.isFullyLocked(hintState, ht.block.id));
-          var blockFill = alreadyLocked ? '#ccc' : '#43A047';
-          R.roundRect(ctx, ht.x, ht.y, ht.w, ht.h, 6, blockFill);
-          R.text(ctx, ht.block.label, ht.x + ht.w / 2, ht.y + ht.h / 2 - 8, 18, '#fff', 'center');
+          ctx.globalAlpha = alreadyLocked ? 0.4 : 0.95;
+          R.roundRect(ctx, ht.x, ht.y, ht.w, ht.h, 10, ht.block.color);
+          if (alreadyLocked) {
+            R.textBold(ctx, '✓', ht.x + ht.w / 2, ht.y + ht.h / 2, 20, '#fff', 'center', 'middle');
+          } else {
+            var ihs = Math.min(
+              Math.floor((ht.w - 12) / ht.block.shape[0].length),
+              Math.floor((ht.h - 12) / ht.block.shape.length)
+            );
+            var ihw = ht.block.shape[0].length * ihs;
+            var ihh = ht.block.shape.length * ihs;
+            R.blockShape(ctx, ht.block.shape, '#fff', ht.x + (ht.w - ihw) / 2, ht.y + (ht.h - ihh) / 2, ihs, 0.9);
+          }
+          ctx.globalAlpha = 1;
         }
       }
 

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -53,6 +53,7 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
   var timer = 0;
   var isWon = false;
   var hintMode = false;
+  var hintTier = null;
   var hintState = Hint.createHintState(
     puzzle.dateStr + ':' + difficulty + ':c' + puzzle.currentComboIndex
   );
@@ -541,18 +542,34 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
 
     // Hint popup
     if (hintMode) {
-      var popW = W * 0.78, popH = H * 0.55;
+      var popW = W * 0.78, popH = 240;
       L.hintPopup = { x: (W - popW) / 2, y: (H - popH) / 2, w: popW, h: popH };
-      var candidates = [];
-      for (var ci2 = 0; ci2 < palette.length; ci2++) candidates.push(palette[ci2]);
-      for (var cj = 0; cj < dropped.length; cj++) candidates.push(dropped[cj]);
-      L.hintItems = [];
-      var hx = L.hintPopup.x + 20, hy = L.hintPopup.y + 50;
-      var hSize = 52, hGap = 10;
-      for (var hi = 0; hi < candidates.length; hi++) {
-        if (hx + hSize > L.hintPopup.x + L.hintPopup.w - 20) { hx = L.hintPopup.x + 20; hy += hSize + hGap; }
-        L.hintItems.push({ x: hx, y: hy, w: hSize, h: hSize, block: candidates[hi] });
-        hx += hSize + hGap;
+
+      if (!hintTier) {
+        L.hintTierBtns = [];
+        var rowH = 50, rowGap = 8;
+        var rowY = L.hintPopup.y + 50;
+        var tiers = ['weak', 'medium', 'strong'];
+        for (var ti = 0; ti < tiers.length; ti++) {
+          L.hintTierBtns.push({
+            x: L.hintPopup.x + 20, y: rowY + ti * (rowH + rowGap),
+            w: popW - 40, h: rowH, tier: tiers[ti],
+          });
+        }
+        L.hintItems = [];
+      } else {
+        var candidates = [];
+        for (var ci2 = 0; ci2 < palette.length; ci2++) candidates.push(palette[ci2]);
+        for (var cj = 0; cj < dropped.length; cj++) candidates.push(dropped[cj]);
+        L.hintItems = [];
+        var hx = L.hintPopup.x + 20, hy = L.hintPopup.y + 50;
+        var hSize = 52, hGap = 10;
+        for (var hi = 0; hi < candidates.length; hi++) {
+          if (hx + hSize > L.hintPopup.x + L.hintPopup.w - 20) { hx = L.hintPopup.x + 20; hy += hSize + hGap; }
+          L.hintItems.push({ x: hx, y: hy, w: hSize, h: hSize, block: candidates[hi] });
+          hx += hSize + hGap;
+        }
+        L.hintTierBtns = [];
       }
       L.hintCloseBtn = { x: L.hintPopup.x + (popW - 90) / 2, y: L.hintPopup.y + popH - 46, w: 90, h: 34 };
     }
@@ -823,26 +840,43 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
     if (hintMode && L.hintPopup) {
       R.overlay(ctx, W, H);
       R.roundRect(ctx, L.hintPopup.x, L.hintPopup.y, L.hintPopup.w, L.hintPopup.h, 16, '#fff');
-      R.textBold(ctx, '选择要提示的方块', L.hintPopup.x + L.hintPopup.w / 2, L.hintPopup.y + 18, 17, '#333', 'center');
-      for (var hi2 = 0; hi2 < L.hintItems.length; hi2++) {
-        var ht = L.hintItems[hi2];
-        var alreadyHinted = Hint.isOrientationLocked(hintState, ht.block.id);
-        ctx.globalAlpha = alreadyHinted ? 0.4 : 0.95;
-        R.roundRect(ctx, ht.x, ht.y, ht.w, ht.h, 10, ht.block.color);
-        if (alreadyHinted) {
-          R.textBold(ctx, '✓', ht.x + ht.w / 2, ht.y + ht.h / 2, 20, '#fff', 'center', 'middle');
-        } else {
-          var ihs = Math.min(
-            Math.floor((ht.w - 12) / ht.block.shape[0].length),
-            Math.floor((ht.h - 12) / ht.block.shape.length)
-          );
-          var ihw = ht.block.shape[0].length * ihs;
-          var ihh = ht.block.shape.length * ihs;
-          R.blockShape(ctx, ht.block.shape, '#fff', ht.x + (ht.w - ihw) / 2, ht.y + (ht.h - ihh) / 2, ihs, 0.9);
+
+      if (!hintTier) {
+        R.textBold(ctx, '选择提示等级', L.hintPopup.x + L.hintPopup.w / 2, L.hintPopup.y + 18, 17, '#333', 'center');
+        var tierLabels = {
+          weak:   '弱：揭示方向（旋转+镜像）',
+          medium: '中：揭示落点格子（不告诉方向）',
+          strong: '强：直接放置（自动腾位）',
+        };
+        var costLabels = {
+          weak:   Hint.COSTS.weak + ' 体力 / 关',
+          medium: Hint.COSTS.medium + ' 体力',
+          strong: Hint.COSTS.strong + ' 体力',
+        };
+        for (var ti2 = 0; ti2 < L.hintTierBtns.length; ti2++) {
+          var btn = L.hintTierBtns[ti2];
+          var used = Hint.countUsed(hintState, btn.tier);
+          var cap = Hint.CAPS[btn.tier];
+          var disabled = used >= cap;
+          var fill = disabled ? '#eee' : (btn.tier === 'strong' ? '#E53935' : btn.tier === 'medium' ? '#FB8C00' : BRAND);
+          R.roundRect(ctx, btn.x, btn.y, btn.w, btn.h, 8, fill);
+          R.text(ctx, tierLabels[btn.tier], btn.x + 12, btn.y + 8, 14, disabled ? '#999' : '#fff', 'left');
+          R.text(ctx, costLabels[btn.tier] + '  ' + used + '/' + cap, btn.x + 12, btn.y + 28, 11, disabled ? '#999' : 'rgba(255,255,255,0.85)', 'left');
         }
-        ctx.globalAlpha = 1;
+      } else {
+        R.textBold(ctx, '选择要提示的方块', L.hintPopup.x + L.hintPopup.w / 2, L.hintPopup.y + 18, 17, '#333', 'center');
+        for (var hi2 = 0; hi2 < L.hintItems.length; hi2++) {
+          var ht = L.hintItems[hi2];
+          var alreadyLocked = (hintTier === 'weak' && Hint.isOrientationLocked(hintState, ht.block.id))
+                           || (hintTier === 'medium' && Hint.isCellLocked(hintState, ht.block.id))
+                           || (hintTier === 'strong' && Hint.isFullyLocked(hintState, ht.block.id));
+          var blockFill = alreadyLocked ? '#ccc' : '#43A047';
+          R.roundRect(ctx, ht.x, ht.y, ht.w, ht.h, 6, blockFill);
+          R.text(ctx, ht.block.label, ht.x + ht.w / 2, ht.y + ht.h / 2 - 8, 18, '#fff', 'center');
+        }
       }
-      R.button(ctx, L.hintCloseBtn.x, L.hintCloseBtn.y, L.hintCloseBtn.w, L.hintCloseBtn.h, '取消', '#eee', '#333', 8);
+
+      R.button(ctx, L.hintCloseBtn.x, L.hintCloseBtn.y, L.hintCloseBtn.w, L.hintCloseBtn.h, hintTier ? '返回' : '取消', '#eee', '#333', 8);
     }
 
     // --- Select panel popup ---
@@ -1564,27 +1598,76 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
 
     // Hint popup
     if (hintMode) {
-      for (var hi3 = 0; hi3 < L.hintItems.length; hi3++) {
-        if (R.hitTest(x, y, L.hintItems[hi3])) {
-          var hBlock = L.hintItems[hi3].block;
-          if (Hint.isOrientationLocked(hintState, hBlock.id)) return;
-          var res = Hint.applyWeak(hintState, hBlock.id, palette, dropped, solvedPlacements);
-          hintState = res.newState;
-          palette = res.updatedPalette;
-          dropped = res.updatedDropped;
-          if (selected && selected.id === hBlock.id) {
-            for (var sp2 = 0; sp2 < palette.length; sp2++) {
-              if (palette[sp2].id === hBlock.id) selected.shape = palette[sp2].shape;
+      // Tier selection
+      if (!hintTier && L.hintTierBtns) {
+        for (var tb = 0; tb < L.hintTierBtns.length; tb++) {
+          if (R.hitTest(x, y, L.hintTierBtns[tb])) {
+            var pickedTier = L.hintTierBtns[tb].tier;
+            if (Hint.countUsed(hintState, pickedTier) >= Hint.CAPS[pickedTier]) {
+              showToast('本关该提示已用完');
+              return;
             }
+            var cost = Hint.COSTS[pickedTier];
+            var have = stamina.getStamina();
+            if (have < cost) {
+              showToast('体力不足！需要 ' + cost + ' 点，当前 ' + have);
+              return;
+            }
+            if (!stamina.consumeStamina(cost)) {
+              showToast('体力扣减失败');
+              return;
+            }
+            hintTier = pickedTier;
+            scene.dirty = true;
+            return;
           }
-          hintMode = false;
-          scene.dirty = true;
-          showToast('已提示 ' + hBlock.label + ' 的正确方向');
-          return;
         }
       }
-      if (L.hintCloseBtn && R.hitTest(x, y, L.hintCloseBtn)) { hintMode = false; scene.dirty = true; return; }
-      if (L.hintPopup && !R.hitTest(x, y, L.hintPopup)) { hintMode = false; scene.dirty = true; return; }
+      // Block selection
+      if (hintTier) {
+        for (var hi3 = 0; hi3 < L.hintItems.length; hi3++) {
+          if (R.hitTest(x, y, L.hintItems[hi3])) {
+            var hBlock = L.hintItems[hi3].block;
+            var res;
+            if (hintTier === 'weak') {
+              if (Hint.isOrientationLocked(hintState, hBlock.id)) { showToast('该方块方向已提示过'); return; }
+              res = Hint.applyWeak(hintState, hBlock.id, palette, dropped, solvedPlacements);
+              showToast('已提示 ' + hBlock.label + ' 的正确方向');
+            } else if (hintTier === 'medium') {
+              if (Hint.isCellLocked(hintState, hBlock.id)) { showToast('该方块位置已提示过'); return; }
+              res = Hint.applyMedium(hintState, hBlock.id, palette, dropped, solvedPlacements);
+              showToast('已提示 ' + hBlock.label + ' 的落点');
+            } else {
+              if (Hint.isFullyLocked(hintState, hBlock.id)) { showToast('该方块已强提示'); return; }
+              res = Hint.applyStrong(hintState, hBlock.id, palette, dropped, solvedPlacements);
+              showToast('已为 ' + hBlock.label + ' 落子');
+            }
+            hintState = res.newState;
+            palette = res.updatedPalette;
+            dropped = res.updatedDropped;
+            if (selected) {
+              for (var sp3 = 0; sp3 < palette.length; sp3++) {
+                if (palette[sp3].id === selected.id) selected.shape = palette[sp3].shape;
+              }
+            }
+            hintMode = false;
+            hintTier = null;
+            scene.dirty = true;
+            return;
+          }
+        }
+      }
+      if (L.hintCloseBtn && R.hitTest(x, y, L.hintCloseBtn)) {
+        if (hintTier) {
+          hintTier = null;
+        } else {
+          hintMode = false;
+        }
+        scene.dirty = true; return;
+      }
+      if (L.hintPopup && !R.hitTest(x, y, L.hintPopup)) {
+        hintMode = false; hintTier = null; scene.dirty = true; return;
+      }
       return;
     }
 

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -1526,6 +1526,13 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
       // `dropped`) once the user has actually moved past the threshold.
       // A tap that never crosses the threshold won't disturb the board.
       if (dragFromBoard) {
+        if (Hint.isFullyLocked(hintState, dragging.id)) {
+          showToast('该方块由强提示锁定');
+          dragging = null;
+          dragFromBoard = false;
+          dragHasMoved = false;
+          return;
+        }
         dropped = dropped.filter(function (b) { return b.id !== dragging.id; });
       }
     }
@@ -1630,13 +1637,12 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
               return;
             }
             var cost = Hint.COSTS[pickedTier];
+            if (pickedTier === 'weak' && Hint.FIRST_WEAK_FREE && Hint.countUsed(hintState, 'weak') === 0) {
+              cost = 0;
+            }
             var have = stamina.getStamina();
             if (have < cost) {
               showToast('体力不足！需要 ' + cost + ' 点，当前 ' + have);
-              return;
-            }
-            if (!stamina.consumeStamina(cost)) {
-              showToast('体力扣减失败');
               return;
             }
             hintTier = pickedTier;
@@ -1650,6 +1656,14 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
         for (var hi3 = 0; hi3 < L.hintItems.length; hi3++) {
           if (R.hitTest(x, y, L.hintItems[hi3])) {
             var hBlock = L.hintItems[hi3].block;
+            var blockCost = Hint.COSTS[hintTier];
+            if (hintTier === 'weak' && Hint.FIRST_WEAK_FREE && Hint.countUsed(hintState, 'weak') === 0) {
+              blockCost = 0;
+            }
+            if (blockCost > 0 && !stamina.consumeStamina(blockCost)) {
+              showToast('体力扣减失败');
+              return;
+            }
             var res;
             if (hintTier === 'weak') {
               if (Hint.isOrientationLocked(hintState, hBlock.id)) { showToast('该方块方向已提示过'); return; }

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -1440,6 +1440,10 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
       var bty = Math.floor((y - L.boardY) / bcs);
       if (btx >= 0 && btx < 7 && bty >= 0 && bty < 8 && x >= L.boardX && y >= L.boardY) {
         var blkAt = B.getBlockAtCell(allBlocks(), btx, bty);
+        if (blkAt && Hint.isFullyLocked(hintState, blkAt.id)) {
+          showToast('该方块由强提示锁定');
+          return;
+        }
         if (blkAt && !isPrePlaced(blkAt.id)) {
           // Lift a board block — but DON'T remove it from `dropped` yet.
           // Removal happens on the first onTouchMove past the drag threshold,
@@ -1703,7 +1707,15 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
           var dbl = (now - lastTap.time < 350) && lastTap.x === tx && lastTap.y === ty;
           lastTap = { time: now, x: tx, y: ty };
           if (dbl) {
-            removeDropped(dragging.id);
+            if (Hint.isFullyLocked(hintState, dragging.id)) {
+              wx.showModal({
+                title: '强提示锁定',
+                content: '这是强提示锁定的方块，不能移除。',
+                showCancel: false,
+              });
+            } else {
+              removeDropped(dragging.id);
+            }
           }
           // single tap: leave the board untouched
         } else {
@@ -1821,7 +1833,13 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
 
       if (dblTap) {
         var blockAt = B.getBlockAtCell(allBlocks(), tapCX, tapCY);
-        if (blockAt && !isPrePlaced(blockAt.id)) {
+        if (blockAt && Hint.isFullyLocked(hintState, blockAt.id)) {
+          wx.showModal({
+            title: '强提示锁定',
+            content: '这是强提示锁定的方块，不能移除。',
+            showCancel: false,
+          });
+        } else if (blockAt && !isPrePlaced(blockAt.id)) {
           removeDropped(blockAt.id);
         } else if (blockAt && isPrePlaced(blockAt.id)) {
           showToast('🔒 题面方块不可移除');

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -732,6 +732,24 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
           drawCellDecoration(ctx, cell.t, px, py, cs);
         }
 
+        // Medium-hint cell overlay (shows where a block should go, no orientation)
+        for (var ml in hintState.mediumLocked) {
+          var mlc = hintState.mediumLocked[ml];
+          // The cell (mlc.x, mlc.y) is the block origin. We highlight ONLY the origin cell —
+          // user still doesn't know the shape.
+          if (mlc.x === bx && mlc.y === by) {
+            // Find block color from palette/dropped (each block has a `color` field
+            // from initialBlockTypes; see board.js:15-24)
+            var blkColor = '#888';
+            for (var pp = 0; pp < palette.length; pp++) if (palette[pp].id === ml) blkColor = palette[pp].color || blkColor;
+            for (var dp = 0; dp < dropped.length; dp++) if (dropped[dp].id === ml) blkColor = dropped[dp].color || blkColor;
+            ctx.save();
+            ctx.globalAlpha = 0.35;
+            R.roundRect(ctx, px, py, cs, cs, 4, blkColor);
+            ctx.restore();
+          }
+        }
+
         // Border (lightest possible)
         if (!blockAt) {
           ctx.strokeStyle = 'rgba(0,0,0,0.08)';

--- a/calendar-puzzle-miniprogram/minigame/js/hint.js
+++ b/calendar-puzzle-miniprogram/minigame/js/hint.js
@@ -1,6 +1,6 @@
 // 3-tier hint state machine. Pure JS — no wx.* calls. Tested with node --test.
 
-var CAPS = { weak: 5, strong: 1 };
+var CAPS = { weak: 3, medium: 3, strong: 1 };
 var COSTS = { weak: 1, medium: 2, strong: 6 };
 var FIRST_WEAK_FREE = true;
 
@@ -37,8 +37,7 @@ function isFullyLocked(state, blockId) {
 }
 
 function canUse(state, type) {
-  if (!(type in CAPS)) return true; // no cap for this tier (e.g., medium)
-  return countUsed(state, type) < CAPS[type];
+  return countUsed(state, type) < (CAPS[type] || 0);
 }
 
 function _shapeEq(a, b) {
@@ -133,20 +132,21 @@ function applyMedium(state, blockId, palette, dropped, solvedPlacements) {
     return { newState: state, updatedPalette: palette, updatedDropped: dropped, hintedCell: null };
   }
 
-  // Find next unrevealed filled cell (row-major)
-  var newCell = null;
-  for (var dy = 0; dy < target.shape.length && !newCell; dy++) {
-    for (var dx = 0; dx < target.shape[dy].length && !newCell; dx++) {
+  // Collect ALL unrevealed filled cells and pick one uniformly at random
+  var candidates = [];
+  for (var dy = 0; dy < target.shape.length; dy++) {
+    for (var dx = 0; dx < target.shape[dy].length; dx++) {
       if (target.shape[dy][dx] !== 1) continue;
       var cx = target.x + dx, cy = target.y + dy;
       var already = false;
       for (var e = 0; e < existing.length; e++) {
         if (existing[e].x === cx && existing[e].y === cy) { already = true; break; }
       }
-      if (!already) newCell = { x: cx, y: cy };
+      if (!already) candidates.push({ x: cx, y: cy });
     }
   }
-  if (!newCell) return { newState: state, updatedPalette: palette, updatedDropped: dropped, hintedCell: null };
+  if (candidates.length === 0) return { newState: state, updatedPalette: palette, updatedDropped: dropped, hintedCell: null };
+  var newCell = candidates[Math.floor(Math.random() * candidates.length)];
 
   // Evict block from board if currently placed at wrong origin (same as before)
   var newPalette = palette.map(_cloneBlock);

--- a/calendar-puzzle-miniprogram/minigame/js/hint.js
+++ b/calendar-puzzle-miniprogram/minigame/js/hint.js
@@ -1,7 +1,7 @@
 // 3-tier hint state machine. Pure JS — no wx.* calls. Tested with node --test.
 
 var CAPS = { weak: 5, medium: 3, strong: 1 };
-var COSTS = { weak: 1, medium: 3, strong: 6 };
+var COSTS = { weak: 1, medium: 2, strong: 6 };
 var FIRST_WEAK_FREE = true;
 
 function createHintState(puzzleId) {

--- a/calendar-puzzle-miniprogram/minigame/js/hint.js
+++ b/calendar-puzzle-miniprogram/minigame/js/hint.js
@@ -1,0 +1,48 @@
+// 3-tier hint state machine. Pure JS — no wx.* calls. Tested with node --test.
+
+var CAPS = { weak: 5, medium: 3, strong: 1 };
+var COSTS = { weak: 1, medium: 3, strong: 6 };
+var FIRST_WEAK_FREE = true;
+
+function createHintState(puzzleId) {
+  return {
+    puzzleId: puzzleId,
+    weakLocked: {},
+    mediumLocked: {},
+    strongLocked: {},
+    usedWeak: 0,
+    usedMedium: 0,
+    usedStrong: 0,
+  };
+}
+
+function countUsed(state, type) {
+  if (type === 'weak') return state.usedWeak;
+  if (type === 'medium') return state.usedMedium;
+  if (type === 'strong') return state.usedStrong;
+  return 0;
+}
+
+function isOrientationLocked(state, blockId) {
+  return !!state.weakLocked[blockId] || !!state.strongLocked[blockId];
+}
+
+function isCellLocked(state, blockId) {
+  if (state.strongLocked[blockId]) return state.strongLocked[blockId]; // {x,y} stored
+  return state.mediumLocked[blockId] || null;
+}
+
+function isFullyLocked(state, blockId) {
+  return !!state.strongLocked[blockId];
+}
+
+module.exports = {
+  CAPS: CAPS,
+  COSTS: COSTS,
+  FIRST_WEAK_FREE: FIRST_WEAK_FREE,
+  createHintState: createHintState,
+  countUsed: countUsed,
+  isOrientationLocked: isOrientationLocked,
+  isCellLocked: isCellLocked,
+  isFullyLocked: isFullyLocked,
+};

--- a/calendar-puzzle-miniprogram/minigame/js/hint.js
+++ b/calendar-puzzle-miniprogram/minigame/js/hint.js
@@ -36,6 +36,70 @@ function isFullyLocked(state, blockId) {
   return !!state.strongLocked[blockId];
 }
 
+function _shapeEq(a, b) {
+  if (!a || !b) return false;
+  if (a.length !== b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i].length !== b[i].length) return false;
+    for (var j = 0; j < a[i].length; j++) if (a[i][j] !== b[i][j]) return false;
+  }
+  return true;
+}
+
+function _cloneShape(s) {
+  return s.map(function (row) { return row.slice(); });
+}
+
+function _cloneBlock(b) {
+  var n = {};
+  for (var k in b) {
+    if (k === 'shape') n.shape = _cloneShape(b.shape);
+    else n[k] = b[k];
+  }
+  return n;
+}
+
+function applyWeak(state, blockId, palette, dropped, solvedPlacements) {
+  var target = solvedPlacements[blockId];
+  if (!target) return { newState: state, updatedPalette: palette, updatedDropped: dropped };
+
+  var newPalette = palette.map(_cloneBlock);
+  var newDropped = dropped.map(_cloneBlock);
+
+  // Find block on palette
+  for (var p = 0; p < newPalette.length; p++) {
+    if (newPalette[p].id === blockId) {
+      newPalette[p].shape = _cloneShape(target.shape);
+    }
+  }
+
+  // Find block on board; evict if shape doesn't match solved
+  for (var d = newDropped.length - 1; d >= 0; d--) {
+    if (newDropped[d].id === blockId) {
+      if (!_shapeEq(newDropped[d].shape, target.shape)) {
+        var ev = _cloneBlock(newDropped[d]);
+        ev.shape = _cloneShape(target.shape);
+        delete ev.x; delete ev.y;
+        newPalette.push(ev);
+        newDropped.splice(d, 1);
+      }
+      // already correctly oriented → leave it
+    }
+  }
+
+  var newState = {
+    puzzleId: state.puzzleId,
+    weakLocked: Object.assign({}, state.weakLocked, function () { var o = {}; o[blockId] = true; return o; }()),
+    mediumLocked: state.mediumLocked,
+    strongLocked: state.strongLocked,
+    usedWeak: state.usedWeak + 1,
+    usedMedium: state.usedMedium,
+    usedStrong: state.usedStrong,
+  };
+
+  return { newState: newState, updatedPalette: newPalette, updatedDropped: newDropped };
+}
+
 module.exports = {
   CAPS: CAPS,
   COSTS: COSTS,
@@ -45,4 +109,5 @@ module.exports = {
   isOrientationLocked: isOrientationLocked,
   isCellLocked: isCellLocked,
   isFullyLocked: isFullyLocked,
+  applyWeak: applyWeak,
 };

--- a/calendar-puzzle-miniprogram/minigame/js/hint.js
+++ b/calendar-puzzle-miniprogram/minigame/js/hint.js
@@ -1,6 +1,6 @@
 // 3-tier hint state machine. Pure JS — no wx.* calls. Tested with node --test.
 
-var CAPS = { weak: 5, medium: 3, strong: 1 };
+var CAPS = { weak: 5, strong: 1 };
 var COSTS = { weak: 1, medium: 2, strong: 6 };
 var FIRST_WEAK_FREE = true;
 
@@ -28,8 +28,8 @@ function isOrientationLocked(state, blockId) {
 }
 
 function isCellLocked(state, blockId) {
-  if (state.strongLocked[blockId]) return state.strongLocked[blockId]; // {x,y} stored
-  return state.mediumLocked[blockId] || null;
+  var cells = state.mediumLocked[blockId];
+  return (cells && cells.length) ? cells : null;
 }
 
 function isFullyLocked(state, blockId) {
@@ -37,7 +37,8 @@ function isFullyLocked(state, blockId) {
 }
 
 function canUse(state, type) {
-  return countUsed(state, type) < (CAPS[type] || 0);
+  if (!(type in CAPS)) return true; // no cap for this tier (e.g., medium)
+  return countUsed(state, type) < CAPS[type];
 }
 
 function _shapeEq(a, b) {
@@ -104,13 +105,52 @@ function applyWeak(state, blockId, palette, dropped, solvedPlacements) {
   return { newState: newState, updatedPalette: newPalette, updatedDropped: newDropped };
 }
 
+function _countShape(shape) {
+  var n = 0;
+  for (var i = 0; i < shape.length; i++) {
+    for (var j = 0; j < shape[i].length; j++) {
+      if (shape[i][j] === 1) n++;
+    }
+  }
+  return n;
+}
+
+function isMediumExhausted(state, blockId, solvedPlacements) {
+  var target = solvedPlacements && solvedPlacements[blockId];
+  if (!target) return true;
+  var existing = state.mediumLocked[blockId] || [];
+  return existing.length >= _countShape(target.shape);
+}
+
 function applyMedium(state, blockId, palette, dropped, solvedPlacements) {
   var target = solvedPlacements[blockId];
   if (!target) return { newState: state, updatedPalette: palette, updatedDropped: dropped, hintedCell: null };
 
+  var existing = state.mediumLocked[blockId] || [];
+  var totalCells = _countShape(target.shape);
+  if (existing.length >= totalCells) {
+    // Defensive: caller should check isMediumExhausted first
+    return { newState: state, updatedPalette: palette, updatedDropped: dropped, hintedCell: null };
+  }
+
+  // Find next unrevealed filled cell (row-major)
+  var newCell = null;
+  for (var dy = 0; dy < target.shape.length && !newCell; dy++) {
+    for (var dx = 0; dx < target.shape[dy].length && !newCell; dx++) {
+      if (target.shape[dy][dx] !== 1) continue;
+      var cx = target.x + dx, cy = target.y + dy;
+      var already = false;
+      for (var e = 0; e < existing.length; e++) {
+        if (existing[e].x === cx && existing[e].y === cy) { already = true; break; }
+      }
+      if (!already) newCell = { x: cx, y: cy };
+    }
+  }
+  if (!newCell) return { newState: state, updatedPalette: palette, updatedDropped: dropped, hintedCell: null };
+
+  // Evict block from board if currently placed at wrong origin (same as before)
   var newPalette = palette.map(_cloneBlock);
   var newDropped = dropped.map(_cloneBlock);
-
   for (var d = newDropped.length - 1; d >= 0; d--) {
     if (newDropped[d].id === blockId) {
       if (newDropped[d].x !== target.x || newDropped[d].y !== target.y) {
@@ -122,10 +162,8 @@ function applyMedium(state, blockId, palette, dropped, solvedPlacements) {
     }
   }
 
-  var displayCell = _firstFilledCell(target.shape, target.x, target.y);
-
   var newMed = Object.assign({}, state.mediumLocked);
-  newMed[blockId] = displayCell;
+  newMed[blockId] = existing.concat([newCell]);
 
   var newState = {
     puzzleId: state.puzzleId,
@@ -137,7 +175,7 @@ function applyMedium(state, blockId, palette, dropped, solvedPlacements) {
     usedStrong: state.usedStrong,
   };
 
-  return { newState: newState, updatedPalette: newPalette, updatedDropped: newDropped, hintedCell: displayCell };
+  return { newState: newState, updatedPalette: newPalette, updatedDropped: newDropped, hintedCell: newCell };
 }
 
 function _firstFilledCell(shape, originX, originY) {
@@ -243,6 +281,7 @@ module.exports = {
   isOrientationLocked: isOrientationLocked,
   isCellLocked: isCellLocked,
   isFullyLocked: isFullyLocked,
+  isMediumExhausted: isMediumExhausted,
   applyWeak: applyWeak,
   applyMedium: applyMedium,
   applyStrong: applyStrong,

--- a/calendar-puzzle-miniprogram/minigame/js/hint.js
+++ b/calendar-puzzle-miniprogram/minigame/js/hint.js
@@ -122,8 +122,10 @@ function applyMedium(state, blockId, palette, dropped, solvedPlacements) {
     }
   }
 
+  var displayCell = _firstFilledCell(target.shape, target.x, target.y);
+
   var newMed = Object.assign({}, state.mediumLocked);
-  newMed[blockId] = { x: target.x, y: target.y };
+  newMed[blockId] = displayCell;
 
   var newState = {
     puzzleId: state.puzzleId,
@@ -135,7 +137,16 @@ function applyMedium(state, blockId, palette, dropped, solvedPlacements) {
     usedStrong: state.usedStrong,
   };
 
-  return { newState: newState, updatedPalette: newPalette, updatedDropped: newDropped, hintedCell: { x: target.x, y: target.y } };
+  return { newState: newState, updatedPalette: newPalette, updatedDropped: newDropped, hintedCell: displayCell };
+}
+
+function _firstFilledCell(shape, originX, originY) {
+  for (var dy = 0; dy < shape.length; dy++) {
+    for (var dx = 0; dx < shape[dy].length; dx++) {
+      if (shape[dy][dx] === 1) return { x: originX + dx, y: originY + dy };
+    }
+  }
+  return { x: originX, y: originY }; // fallback (shouldn't happen for valid shapes)
 }
 
 function _cellsOf(block) {

--- a/calendar-puzzle-miniprogram/minigame/js/hint.js
+++ b/calendar-puzzle-miniprogram/minigame/js/hint.js
@@ -100,6 +100,40 @@ function applyWeak(state, blockId, palette, dropped, solvedPlacements) {
   return { newState: newState, updatedPalette: newPalette, updatedDropped: newDropped };
 }
 
+function applyMedium(state, blockId, palette, dropped, solvedPlacements) {
+  var target = solvedPlacements[blockId];
+  if (!target) return { newState: state, updatedPalette: palette, updatedDropped: dropped, hintedCell: null };
+
+  var newPalette = palette.map(_cloneBlock);
+  var newDropped = dropped.map(_cloneBlock);
+
+  for (var d = newDropped.length - 1; d >= 0; d--) {
+    if (newDropped[d].id === blockId) {
+      if (newDropped[d].x !== target.x || newDropped[d].y !== target.y) {
+        var ev = _cloneBlock(newDropped[d]);
+        delete ev.x; delete ev.y;
+        newPalette.push(ev);
+        newDropped.splice(d, 1);
+      }
+    }
+  }
+
+  var newMed = Object.assign({}, state.mediumLocked);
+  newMed[blockId] = { x: target.x, y: target.y };
+
+  var newState = {
+    puzzleId: state.puzzleId,
+    weakLocked: state.weakLocked,
+    mediumLocked: newMed,
+    strongLocked: state.strongLocked,
+    usedWeak: state.usedWeak,
+    usedMedium: state.usedMedium + 1,
+    usedStrong: state.usedStrong,
+  };
+
+  return { newState: newState, updatedPalette: newPalette, updatedDropped: newDropped, hintedCell: { x: target.x, y: target.y } };
+}
+
 module.exports = {
   CAPS: CAPS,
   COSTS: COSTS,
@@ -110,4 +144,5 @@ module.exports = {
   isCellLocked: isCellLocked,
   isFullyLocked: isFullyLocked,
   applyWeak: applyWeak,
+  applyMedium: applyMedium,
 };

--- a/calendar-puzzle-miniprogram/minigame/js/hint.js
+++ b/calendar-puzzle-miniprogram/minigame/js/hint.js
@@ -134,6 +134,90 @@ function applyMedium(state, blockId, palette, dropped, solvedPlacements) {
   return { newState: newState, updatedPalette: newPalette, updatedDropped: newDropped, hintedCell: { x: target.x, y: target.y } };
 }
 
+function _cellsOf(block) {
+  var cells = [];
+  for (var dy = 0; dy < block.shape.length; dy++) {
+    for (var dx = 0; dx < block.shape[dy].length; dx++) {
+      if (block.shape[dy][dx] === 1) cells.push({ x: block.x + dx, y: block.y + dy });
+    }
+  }
+  return cells;
+}
+
+function applyStrong(state, blockId, palette, dropped, solvedPlacements) {
+  var target = solvedPlacements[blockId];
+  if (!target) return { newState: state, updatedPalette: palette, updatedDropped: dropped, evictedIds: [] };
+
+  var newPalette = palette.map(_cloneBlock);
+  var newDropped = dropped.map(_cloneBlock);
+
+  // Cells that the target placement will occupy
+  var targetCells = _cellsOf({ x: target.x, y: target.y, shape: target.shape });
+  var occ = {};
+  for (var i = 0; i < targetCells.length; i++) occ[targetCells[i].x + ',' + targetCells[i].y] = true;
+
+  // Evict any dropped block (other than blockId) that overlaps
+  var evictedIds = [];
+  for (var d = newDropped.length - 1; d >= 0; d--) {
+    var b = newDropped[d];
+    if (b.id === blockId) {
+      newDropped.splice(d, 1); // remove old placement (will re-place)
+      continue;
+    }
+    var bCells = _cellsOf(b);
+    for (var c = 0; c < bCells.length; c++) {
+      if (occ[bCells[c].x + ',' + bCells[c].y]) {
+        var ev = _cloneBlock(b);
+        delete ev.x; delete ev.y;
+        newPalette.push(ev);
+        newDropped.splice(d, 1);
+        evictedIds.push(b.id);
+        break;
+      }
+    }
+  }
+
+  // Pull blockId out of palette if present
+  for (var p = newPalette.length - 1; p >= 0; p--) {
+    if (newPalette[p].id === blockId) newPalette.splice(p, 1);
+  }
+
+  // Place at solved position
+  newDropped.push({
+    id: blockId,
+    label: target.shape && target.shape.length ? blockId.charAt(0) : '',
+    shape: _cloneShape(target.shape),
+    x: target.x,
+    y: target.y,
+  });
+  // Pull label/extra fields from the original block if available
+  var sourceBlock = null;
+  for (var sp = 0; sp < palette.length; sp++) if (palette[sp].id === blockId) sourceBlock = palette[sp];
+  for (var sd = 0; sd < dropped.length; sd++) if (dropped[sd].id === blockId) sourceBlock = dropped[sd];
+  if (sourceBlock) {
+    var placed = newDropped[newDropped.length - 1];
+    for (var k in sourceBlock) {
+      if (k === 'shape' || k === 'x' || k === 'y') continue;
+      placed[k] = sourceBlock[k];
+    }
+  }
+
+  var newStrong = Object.assign({}, state.strongLocked);
+  newStrong[blockId] = { x: target.x, y: target.y };
+
+  var newState = {
+    puzzleId: state.puzzleId,
+    weakLocked: state.weakLocked,
+    mediumLocked: state.mediumLocked,
+    strongLocked: newStrong,
+    usedWeak: state.usedWeak,
+    usedMedium: state.usedMedium,
+    usedStrong: state.usedStrong + 1,
+  };
+
+  return { newState: newState, updatedPalette: newPalette, updatedDropped: newDropped, evictedIds: evictedIds };
+}
+
 module.exports = {
   CAPS: CAPS,
   COSTS: COSTS,
@@ -145,4 +229,5 @@ module.exports = {
   isFullyLocked: isFullyLocked,
   applyWeak: applyWeak,
   applyMedium: applyMedium,
+  applyStrong: applyStrong,
 };

--- a/calendar-puzzle-miniprogram/minigame/js/hint.js
+++ b/calendar-puzzle-miniprogram/minigame/js/hint.js
@@ -36,6 +36,10 @@ function isFullyLocked(state, blockId) {
   return !!state.strongLocked[blockId];
 }
 
+function canUse(state, type) {
+  return countUsed(state, type) < (CAPS[type] || 0);
+}
+
 function _shapeEq(a, b) {
   if (!a || !b) return false;
   if (a.length !== b.length) return false;
@@ -224,6 +228,7 @@ module.exports = {
   FIRST_WEAK_FREE: FIRST_WEAK_FREE,
   createHintState: createHintState,
   countUsed: countUsed,
+  canUse: canUse,
   isOrientationLocked: isOrientationLocked,
   isCellLocked: isCellLocked,
   isFullyLocked: isFullyLocked,

--- a/calendar-puzzle-miniprogram/minigame/js/puzzleGenerator.js
+++ b/calendar-puzzle-miniprogram/minigame/js/puzzleGenerator.js
@@ -431,7 +431,7 @@ function _findLegalPlacement(block, prePlaced, uncov, solvedPlacement) {
 }
 
 // Build solved placements lookup (block id → {x, y, shape}) from a solved board.
-function _solvedPlacements(sb) {
+function solvedPlacements(sb) {
   var map = {};
   var all = boardToPlaced(sb);
   for (var i = 0; i < all.length; i++) {
@@ -513,7 +513,7 @@ function generateTutorialPuzzle(date) {
     var sb2 = bases[bi];
     var letterSets = enumAllDigCombinations(sb2, digCount);
     if (!letterSets.length) continue;
-    var sps = _solvedPlacements(sb2);
+    var sps = solvedPlacements(sb2);
     for (var li = 0; li < letterSets.length && !winningTriple && attempts < MAX_TUTORIAL_ATTEMPTS; li++) {
       attempts++;
       var pts = puzzleFromCombo(sb2, letterSets[li]);
@@ -612,4 +612,5 @@ module.exports = {
   DIFFICULTY_CONFIG: DIFFICULTY_CONFIG,
   formatDateStr: formatDateStr,
   parseDateStr: parseDateStr,
+  solvedPlacements: solvedPlacements,
 };

--- a/calendar-puzzle-miniprogram/package.json
+++ b/calendar-puzzle-miniprogram/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "calendar-puzzle-miniprogram-tests",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/calendar-puzzle-miniprogram/tests/hint.test.js
+++ b/calendar-puzzle-miniprogram/tests/hint.test.js
@@ -3,7 +3,7 @@ var assert = require('node:assert');
 var H = require('../minigame/js/hint');
 
 test('CAPS and COSTS are the agreed economy', function () {
-  assert.deepStrictEqual(H.CAPS, { weak: 5, medium: 3, strong: 1 });
+  assert.deepStrictEqual(H.CAPS, { weak: 5, strong: 1 });
   assert.deepStrictEqual(H.COSTS, { weak: 1, medium: 2, strong: 6 });
   assert.strictEqual(H.FIRST_WEAK_FREE, true);
 });
@@ -86,7 +86,7 @@ test('applyMedium records target cell, does NOT change palette shape', function 
 
   assert.deepStrictEqual(res.hintedCell, { x: 3, y: 3 });
   assert.ok(shapeEq(res.updatedPalette[0].shape, [[1, 1], [0, 1]])); // unchanged
-  assert.deepStrictEqual(res.newState.mediumLocked['X-block'], { x: 3, y: 3 });
+  assert.deepStrictEqual(res.newState.mediumLocked['X-block'], [{ x: 3, y: 3 }]);
   assert.strictEqual(res.newState.usedMedium, 1);
 });
 
@@ -155,7 +155,8 @@ test('canUse returns false when cap reached', function () {
   var s = H.createHintState('p1');
   s.usedWeak = 5;
   assert.strictEqual(H.canUse(s, 'weak'), false);
-  assert.strictEqual(H.canUse(s, 'medium'), true);
+  s.usedStrong = 1;
+  assert.strictEqual(H.canUse(s, 'strong'), false);
 });
 
 test('isOrientationLocked true after weak applied', function () {
@@ -171,4 +172,50 @@ test('isFullyLocked true after strong applied', function () {
   var solved = { 'X-block': { x: 0, y: 0, shape: [[1]] } };
   var r = H.applyStrong(s, 'X-block', [{ id: 'X-block', label: 'X', shape: [[1]] }], [], solved);
   assert.strictEqual(H.isFullyLocked(r.newState, 'X-block'), true);
+});
+
+test('applyMedium accumulates a new cell on each call to same block', function () {
+  var state = H.createHintState('p1');
+  var palette = [{ id: 'X-block', label: 'X', shape: [[1, 1], [1, 1]] }];
+  var dropped = [];
+  // 4-cell square at origin (5, 5)
+  var solved = { 'X-block': { x: 5, y: 5, shape: [[1, 1], [1, 1]] } };
+
+  var r1 = H.applyMedium(state, 'X-block', palette, dropped, solved);
+  assert.deepStrictEqual(r1.hintedCell, { x: 5, y: 5 });
+  assert.strictEqual(r1.newState.mediumLocked['X-block'].length, 1);
+
+  var r2 = H.applyMedium(r1.newState, 'X-block', r1.updatedPalette, r1.updatedDropped, solved);
+  assert.deepStrictEqual(r2.hintedCell, { x: 6, y: 5 });
+  assert.strictEqual(r2.newState.mediumLocked['X-block'].length, 2);
+
+  var r3 = H.applyMedium(r2.newState, 'X-block', r2.updatedPalette, r2.updatedDropped, solved);
+  assert.deepStrictEqual(r3.hintedCell, { x: 5, y: 6 });
+
+  var r4 = H.applyMedium(r3.newState, 'X-block', r3.updatedPalette, r3.updatedDropped, solved);
+  assert.deepStrictEqual(r4.hintedCell, { x: 6, y: 6 });
+  assert.strictEqual(r4.newState.mediumLocked['X-block'].length, 4);
+
+  assert.strictEqual(H.isMediumExhausted(r4.newState, 'X-block', solved), true);
+  assert.strictEqual(H.isMediumExhausted(r3.newState, 'X-block', solved), false);
+});
+
+test('applyMedium returns null hintedCell when block exhausted', function () {
+  var state = H.createHintState('p1');
+  var palette = [{ id: 'X-block', label: 'X', shape: [[1]] }];
+  var dropped = [];
+  var solved = { 'X-block': { x: 0, y: 0, shape: [[1]] } };
+
+  var r1 = H.applyMedium(state, 'X-block', palette, dropped, solved);
+  assert.strictEqual(H.isMediumExhausted(r1.newState, 'X-block', solved), true);
+
+  var r2 = H.applyMedium(r1.newState, 'X-block', r1.updatedPalette, r1.updatedDropped, solved);
+  assert.strictEqual(r2.hintedCell, null);
+});
+
+test('canUse always returns true for medium (no cap)', function () {
+  var s = H.createHintState('p1');
+  s.usedMedium = 99;
+  assert.strictEqual(H.canUse(s, 'medium'), true);
+  assert.strictEqual(H.canUse(s, 'weak'), true);  // still under cap 5
 });

--- a/calendar-puzzle-miniprogram/tests/hint.test.js
+++ b/calendar-puzzle-miniprogram/tests/hint.test.js
@@ -1,6 +1,20 @@
 var test = require('node:test');
 var assert = require('node:assert');
+var H = require('../minigame/js/hint');
 
-test('test runner works', function () {
-  assert.strictEqual(1 + 1, 2);
+test('CAPS and COSTS are the agreed economy', function () {
+  assert.deepStrictEqual(H.CAPS, { weak: 5, medium: 3, strong: 1 });
+  assert.deepStrictEqual(H.COSTS, { weak: 1, medium: 3, strong: 6 });
+  assert.strictEqual(H.FIRST_WEAK_FREE, true);
+});
+
+test('createHintState returns fresh empty state', function () {
+  var s = H.createHintState('2026-05-18:hard:c3');
+  assert.strictEqual(s.puzzleId, '2026-05-18:hard:c3');
+  assert.deepStrictEqual(s.weakLocked, {});
+  assert.deepStrictEqual(s.mediumLocked, {});
+  assert.deepStrictEqual(s.strongLocked, {});
+  assert.strictEqual(s.usedWeak, 0);
+  assert.strictEqual(s.usedMedium, 0);
+  assert.strictEqual(s.usedStrong, 0);
 });

--- a/calendar-puzzle-miniprogram/tests/hint.test.js
+++ b/calendar-puzzle-miniprogram/tests/hint.test.js
@@ -18,3 +18,60 @@ test('createHintState returns fresh empty state', function () {
   assert.strictEqual(s.usedMedium, 0);
   assert.strictEqual(s.usedStrong, 0);
 });
+
+function shapeEq(a, b) {
+  if (a.length !== b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i].length !== b[i].length) return false;
+    for (var j = 0; j < a[i].length; j++) if (a[i][j] !== b[i][j]) return false;
+  }
+  return true;
+}
+
+test('applyWeak updates palette block shape to solved orientation', function () {
+  var state = H.createHintState('p1');
+  var palette = [
+    { id: 'X-block', label: 'X', shape: [[1, 1], [0, 1]] },
+  ];
+  var dropped = [];
+  var solved = { 'X-block': { x: 0, y: 0, shape: [[0, 1], [1, 1]] } };
+
+  var res = H.applyWeak(state, 'X-block', palette, dropped, solved);
+
+  assert.ok(shapeEq(res.updatedPalette[0].shape, [[0, 1], [1, 1]]));
+  assert.strictEqual(res.newState.weakLocked['X-block'], true);
+  assert.strictEqual(res.newState.usedWeak, 1);
+  assert.deepStrictEqual(res.updatedDropped, []);
+});
+
+test('applyWeak evicts misplaced block from board back to palette', function () {
+  var state = H.createHintState('p1');
+  var palette = [];
+  var dropped = [
+    { id: 'X-block', label: 'X', shape: [[1, 1], [0, 1]], x: 3, y: 2 },
+  ];
+  var solved = { 'X-block': { x: 0, y: 0, shape: [[0, 1], [1, 1]] } };
+
+  var res = H.applyWeak(state, 'X-block', palette, dropped, solved);
+
+  assert.deepStrictEqual(res.updatedDropped, []);
+  assert.strictEqual(res.updatedPalette.length, 1);
+  assert.strictEqual(res.updatedPalette[0].id, 'X-block');
+  assert.ok(shapeEq(res.updatedPalette[0].shape, [[0, 1], [1, 1]]));
+  assert.strictEqual(res.updatedPalette[0].x, undefined);
+  assert.strictEqual(res.updatedPalette[0].y, undefined);
+});
+
+test('applyWeak keeps block on board if already in solved orientation', function () {
+  var state = H.createHintState('p1');
+  var palette = [];
+  var dropped = [
+    { id: 'X-block', label: 'X', shape: [[0, 1], [1, 1]], x: 0, y: 0 },
+  ];
+  var solved = { 'X-block': { x: 0, y: 0, shape: [[0, 1], [1, 1]] } };
+
+  var res = H.applyWeak(state, 'X-block', palette, dropped, solved);
+
+  assert.strictEqual(res.updatedDropped.length, 1);
+  assert.deepStrictEqual(res.updatedPalette, []);
+});

--- a/calendar-puzzle-miniprogram/tests/hint.test.js
+++ b/calendar-puzzle-miniprogram/tests/hint.test.js
@@ -4,7 +4,7 @@ var H = require('../minigame/js/hint');
 
 test('CAPS and COSTS are the agreed economy', function () {
   assert.deepStrictEqual(H.CAPS, { weak: 5, medium: 3, strong: 1 });
-  assert.deepStrictEqual(H.COSTS, { weak: 1, medium: 3, strong: 6 });
+  assert.deepStrictEqual(H.COSTS, { weak: 1, medium: 2, strong: 6 });
   assert.strictEqual(H.FIRST_WEAK_FREE, true);
 });
 

--- a/calendar-puzzle-miniprogram/tests/hint.test.js
+++ b/calendar-puzzle-miniprogram/tests/hint.test.js
@@ -75,3 +75,42 @@ test('applyWeak keeps block on board if already in solved orientation', function
   assert.strictEqual(res.updatedDropped.length, 1);
   assert.deepStrictEqual(res.updatedPalette, []);
 });
+
+test('applyMedium records target cell, does NOT change palette shape', function () {
+  var state = H.createHintState('p1');
+  var palette = [{ id: 'X-block', label: 'X', shape: [[1, 1], [0, 1]] }];
+  var dropped = [];
+  var solved = { 'X-block': { x: 2, y: 3, shape: [[0, 1], [1, 1]] } };
+
+  var res = H.applyMedium(state, 'X-block', palette, dropped, solved);
+
+  assert.deepStrictEqual(res.hintedCell, { x: 2, y: 3 });
+  assert.ok(shapeEq(res.updatedPalette[0].shape, [[1, 1], [0, 1]])); // unchanged
+  assert.deepStrictEqual(res.newState.mediumLocked['X-block'], { x: 2, y: 3 });
+  assert.strictEqual(res.newState.usedMedium, 1);
+});
+
+test('applyMedium evicts board block placed at wrong cell', function () {
+  var state = H.createHintState('p1');
+  var palette = [];
+  var dropped = [{ id: 'X-block', label: 'X', shape: [[1, 1], [0, 1]], x: 0, y: 0 }];
+  var solved = { 'X-block': { x: 5, y: 5, shape: [[0, 1], [1, 1]] } };
+
+  var res = H.applyMedium(state, 'X-block', palette, dropped, solved);
+
+  assert.deepStrictEqual(res.updatedDropped, []);
+  assert.strictEqual(res.updatedPalette.length, 1);
+  assert.strictEqual(res.updatedPalette[0].x, undefined);
+});
+
+test('applyMedium leaves correctly-positioned block in place', function () {
+  var state = H.createHintState('p1');
+  var palette = [];
+  var dropped = [{ id: 'X-block', label: 'X', shape: [[1, 1], [0, 1]], x: 5, y: 5 }];
+  var solved = { 'X-block': { x: 5, y: 5, shape: [[0, 1], [1, 1]] } };
+
+  var res = H.applyMedium(state, 'X-block', palette, dropped, solved);
+
+  assert.strictEqual(res.updatedDropped.length, 1);
+  assert.strictEqual(res.updatedDropped[0].x, 5);
+});

--- a/calendar-puzzle-miniprogram/tests/hint.test.js
+++ b/calendar-puzzle-miniprogram/tests/hint.test.js
@@ -3,7 +3,7 @@ var assert = require('node:assert');
 var H = require('../minigame/js/hint');
 
 test('CAPS and COSTS are the agreed economy', function () {
-  assert.deepStrictEqual(H.CAPS, { weak: 5, strong: 1 });
+  assert.deepStrictEqual(H.CAPS, { weak: 3, medium: 3, strong: 1 });
   assert.deepStrictEqual(H.COSTS, { weak: 1, medium: 2, strong: 6 });
   assert.strictEqual(H.FIRST_WEAK_FREE, true);
 });
@@ -84,9 +84,13 @@ test('applyMedium records target cell, does NOT change palette shape', function 
 
   var res = H.applyMedium(state, 'X-block', palette, dropped, solved);
 
-  assert.deepStrictEqual(res.hintedCell, { x: 3, y: 3 });
+  // Random pick — must be one of the 3 filled cells of the shape at origin (2,3)
+  var validCells = [{ x: 3, y: 3 }, { x: 2, y: 4 }, { x: 3, y: 4 }];
+  var hit = validCells.some(function (c) { return c.x === res.hintedCell.x && c.y === res.hintedCell.y; });
+  assert.ok(hit, 'hintedCell should be one of the filled cells; got ' + JSON.stringify(res.hintedCell));
+
   assert.ok(shapeEq(res.updatedPalette[0].shape, [[1, 1], [0, 1]])); // unchanged
-  assert.deepStrictEqual(res.newState.mediumLocked['X-block'], [{ x: 3, y: 3 }]);
+  assert.strictEqual(res.newState.mediumLocked['X-block'].length, 1);
   assert.strictEqual(res.newState.usedMedium, 1);
 });
 
@@ -153,8 +157,10 @@ test('applyStrong evicts blockers that overlap the target', function () {
 
 test('canUse returns false when cap reached', function () {
   var s = H.createHintState('p1');
-  s.usedWeak = 5;
+  s.usedWeak = 3;
   assert.strictEqual(H.canUse(s, 'weak'), false);
+  s.usedMedium = 3;
+  assert.strictEqual(H.canUse(s, 'medium'), false);
   s.usedStrong = 1;
   assert.strictEqual(H.canUse(s, 'strong'), false);
 });
@@ -178,26 +184,27 @@ test('applyMedium accumulates a new cell on each call to same block', function (
   var state = H.createHintState('p1');
   var palette = [{ id: 'X-block', label: 'X', shape: [[1, 1], [1, 1]] }];
   var dropped = [];
-  // 4-cell square at origin (5, 5)
   var solved = { 'X-block': { x: 5, y: 5, shape: [[1, 1], [1, 1]] } };
 
-  var r1 = H.applyMedium(state, 'X-block', palette, dropped, solved);
-  assert.deepStrictEqual(r1.hintedCell, { x: 5, y: 5 });
-  assert.strictEqual(r1.newState.mediumLocked['X-block'].length, 1);
+  var cur = state, pal = palette, drp = dropped;
+  var seen = {};
+  for (var i = 0; i < 4; i++) {
+    var r = H.applyMedium(cur, 'X-block', pal, drp, solved);
+    assert.ok(r.hintedCell, 'call ' + i + ' should reveal a cell');
+    var key = r.hintedCell.x + ',' + r.hintedCell.y;
+    assert.ok(!seen[key], 'cell ' + key + ' revealed twice');
+    seen[key] = true;
+    cur = r.newState; pal = r.updatedPalette; drp = r.updatedDropped;
+  }
+  assert.strictEqual(cur.mediumLocked['X-block'].length, 4);
+  assert.strictEqual(H.isMediumExhausted(cur, 'X-block', solved), true);
 
-  var r2 = H.applyMedium(r1.newState, 'X-block', r1.updatedPalette, r1.updatedDropped, solved);
-  assert.deepStrictEqual(r2.hintedCell, { x: 6, y: 5 });
-  assert.strictEqual(r2.newState.mediumLocked['X-block'].length, 2);
+  // 5th call returns null (exhausted)
+  var r5 = H.applyMedium(cur, 'X-block', pal, drp, solved);
+  assert.strictEqual(r5.hintedCell, null);
 
-  var r3 = H.applyMedium(r2.newState, 'X-block', r2.updatedPalette, r2.updatedDropped, solved);
-  assert.deepStrictEqual(r3.hintedCell, { x: 5, y: 6 });
-
-  var r4 = H.applyMedium(r3.newState, 'X-block', r3.updatedPalette, r3.updatedDropped, solved);
-  assert.deepStrictEqual(r4.hintedCell, { x: 6, y: 6 });
-  assert.strictEqual(r4.newState.mediumLocked['X-block'].length, 4);
-
-  assert.strictEqual(H.isMediumExhausted(r4.newState, 'X-block', solved), true);
-  assert.strictEqual(H.isMediumExhausted(r3.newState, 'X-block', solved), false);
+  // All 4 cells of the 2x2 square should have been seen
+  assert.deepStrictEqual(Object.keys(seen).sort(), ['5,5', '5,6', '6,5', '6,6']);
 });
 
 test('applyMedium returns null hintedCell when block exhausted', function () {
@@ -211,11 +218,4 @@ test('applyMedium returns null hintedCell when block exhausted', function () {
 
   var r2 = H.applyMedium(r1.newState, 'X-block', r1.updatedPalette, r1.updatedDropped, solved);
   assert.strictEqual(r2.hintedCell, null);
-});
-
-test('canUse always returns true for medium (no cap)', function () {
-  var s = H.createHintState('p1');
-  s.usedMedium = 99;
-  assert.strictEqual(H.canUse(s, 'medium'), true);
-  assert.strictEqual(H.canUse(s, 'weak'), true);  // still under cap 5
 });

--- a/calendar-puzzle-miniprogram/tests/hint.test.js
+++ b/calendar-puzzle-miniprogram/tests/hint.test.js
@@ -1,0 +1,6 @@
+var test = require('node:test');
+var assert = require('node:assert');
+
+test('test runner works', function () {
+  assert.strictEqual(1 + 1, 2);
+});

--- a/calendar-puzzle-miniprogram/tests/hint.test.js
+++ b/calendar-puzzle-miniprogram/tests/hint.test.js
@@ -114,3 +114,39 @@ test('applyMedium leaves correctly-positioned block in place', function () {
   assert.strictEqual(res.updatedDropped.length, 1);
   assert.strictEqual(res.updatedDropped[0].x, 5);
 });
+
+test('applyStrong places block at solved location with solved shape', function () {
+  var state = H.createHintState('p1');
+  var palette = [{ id: 'X-block', label: 'X', shape: [[1, 1], [0, 1]] }];
+  var dropped = [];
+  var solved = { 'X-block': { x: 2, y: 3, shape: [[0, 1], [1, 1]] } };
+
+  var res = H.applyStrong(state, 'X-block', palette, dropped, solved);
+
+  assert.deepStrictEqual(res.updatedPalette, []);
+  assert.strictEqual(res.updatedDropped.length, 1);
+  assert.strictEqual(res.updatedDropped[0].id, 'X-block');
+  assert.strictEqual(res.updatedDropped[0].x, 2);
+  assert.strictEqual(res.updatedDropped[0].y, 3);
+  assert.ok(shapeEq(res.updatedDropped[0].shape, [[0, 1], [1, 1]]));
+  assert.strictEqual(res.newState.strongLocked['X-block'].x, 2);
+  assert.strictEqual(res.newState.usedStrong, 1);
+  assert.deepStrictEqual(res.evictedIds, []);
+});
+
+test('applyStrong evicts blockers that overlap the target', function () {
+  var state = H.createHintState('p1');
+  var palette = [{ id: 'X-block', label: 'X', shape: [[1, 1], [0, 1]] }];
+  // Y-block is currently placed and overlaps cell (2,3)
+  var dropped = [{ id: 'Y-block', label: 'Y', shape: [[1, 1]], x: 2, y: 3 }];
+  var solved = { 'X-block': { x: 2, y: 3, shape: [[0, 1], [1, 1]] } };
+
+  var res = H.applyStrong(state, 'X-block', palette, dropped, solved);
+
+  assert.deepStrictEqual(res.evictedIds, ['Y-block']);
+  // X-block placed
+  assert.strictEqual(res.updatedDropped.length, 1);
+  assert.strictEqual(res.updatedDropped[0].id, 'X-block');
+  // Y-block back in palette
+  assert.ok(res.updatedPalette.some(function (b) { return b.id === 'Y-block'; }));
+});

--- a/calendar-puzzle-miniprogram/tests/hint.test.js
+++ b/calendar-puzzle-miniprogram/tests/hint.test.js
@@ -84,9 +84,9 @@ test('applyMedium records target cell, does NOT change palette shape', function 
 
   var res = H.applyMedium(state, 'X-block', palette, dropped, solved);
 
-  assert.deepStrictEqual(res.hintedCell, { x: 2, y: 3 });
+  assert.deepStrictEqual(res.hintedCell, { x: 3, y: 3 });
   assert.ok(shapeEq(res.updatedPalette[0].shape, [[1, 1], [0, 1]])); // unchanged
-  assert.deepStrictEqual(res.newState.mediumLocked['X-block'], { x: 2, y: 3 });
+  assert.deepStrictEqual(res.newState.mediumLocked['X-block'], { x: 3, y: 3 });
   assert.strictEqual(res.newState.usedMedium, 1);
 });
 

--- a/calendar-puzzle-miniprogram/tests/hint.test.js
+++ b/calendar-puzzle-miniprogram/tests/hint.test.js
@@ -150,3 +150,25 @@ test('applyStrong evicts blockers that overlap the target', function () {
   // Y-block back in palette
   assert.ok(res.updatedPalette.some(function (b) { return b.id === 'Y-block'; }));
 });
+
+test('canUse returns false when cap reached', function () {
+  var s = H.createHintState('p1');
+  s.usedWeak = 5;
+  assert.strictEqual(H.canUse(s, 'weak'), false);
+  assert.strictEqual(H.canUse(s, 'medium'), true);
+});
+
+test('isOrientationLocked true after weak applied', function () {
+  var s = H.createHintState('p1');
+  var solved = { 'X-block': { x: 0, y: 0, shape: [[1]] } };
+  var r = H.applyWeak(s, 'X-block', [{ id: 'X-block', label: 'X', shape: [[1]] }], [], solved);
+  assert.strictEqual(H.isOrientationLocked(r.newState, 'X-block'), true);
+  assert.strictEqual(H.isOrientationLocked(r.newState, 'Y-block'), false);
+});
+
+test('isFullyLocked true after strong applied', function () {
+  var s = H.createHintState('p1');
+  var solved = { 'X-block': { x: 0, y: 0, shape: [[1]] } };
+  var r = H.applyStrong(s, 'X-block', [{ id: 'X-block', label: 'X', shape: [[1]] }], [], solved);
+  assert.strictEqual(H.isFullyLocked(r.newState, 'X-block'), true);
+});

--- a/docs/superpowers/plans/2026-05-18-hint-system-plan1.md
+++ b/docs/superpowers/plans/2026-05-18-hint-system-plan1.md
@@ -1,0 +1,1272 @@
+# Hint System (Plan 1: Client-Only, Stamina-Source) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Upgrade the existing single-tier weak hint to a full 3-tier (弱/中/强) hint system in the WeChat mini-game, with stamina as the only acquisition source. Independently shippable; lays foundation for Plans 2 (cloud + ads + share + help) and 3 (leaderboard).
+
+**Architecture:** Extract hint logic from `gameScene.js` into a new pure-JS `hint.js` state machine (no `wx.*` calls — testable with `node --test`). `gameScene.js` becomes a thin renderer + event router that delegates to `hint.js`. Existing weak-hint code (gameScene.js:1561-1597, :1670-1692) is migrated to the new module rather than duplicated.
+
+**Tech Stack:** WeChat mini-game vanilla JS (CommonJS, no ES6 in shipped code), Node.js built-in `node --test` runner for unit tests (zero deps).
+
+---
+
+## Spec reference
+
+`docs/superpowers/specs/2026-05-18-social-features-design.md`, sections 1 (goal A), 4.1-4.4, and the local-only subset of 7.
+
+## Pre-existing code that informs the plan
+
+- `minigame/js/gameScene.js:54-55` — `hintMode`, `hintedIds` (used for current single-tier weak hint)
+- `minigame/js/gameScene.js:1561-1597` — current weak-hint apply logic
+- `minigame/js/gameScene.js:1670-1692` — rotate/flip buttons reject when hinted
+- `minigame/js/puzzleGenerator.js:595` — `getHintShape(sb, label)` returns the shape grid; exported
+- `minigame/js/puzzleGenerator.js:434` — `_solvedPlacements(sb)` returns `{id → {x, y, shape}}`; **not currently exported**
+- `minigame/js/board.js` — `rotateShape`, `flipShape`, `isValidPlacement`, `cloneBlock`, `getBlockAtCell`
+- `minigame/js/stamina.js` — `getStamina`, `consumeStamina(cost)`
+
+## File structure for this plan
+
+```
+calendar-puzzle-miniprogram/
+├── package.json                  ← NEW (test runner config, no runtime deps)
+├── tests/
+│   └── hint.test.js              ← NEW (node --test pure-logic tests)
+└── minigame/js/
+    ├── hint.js                   ← NEW (state machine, pure JS)
+    ├── puzzleGenerator.js        ← MODIFY (export solvedPlacements)
+    └── gameScene.js              ← MODIFY (delegate to hint.js + 3-tier UI)
+```
+
+`hint.js` exports:
+- `createHintState(puzzleId)` — fresh state object per puzzle
+- `applyWeak(state, blockId, palette, dropped, solvedPlacements)` → `{ newState, updatedPalette, updatedDropped }`
+- `applyMedium(state, blockId, palette, dropped, solvedPlacements)` → `{ newState, updatedPalette, updatedDropped, hintedCell }`
+- `applyStrong(state, blockId, palette, dropped, solvedPlacements)` → `{ newState, updatedPalette, updatedDropped, evictedIds }`
+- `countUsed(state, type)` → number of hints of `type` consumed this puzzle
+- `CAPS = { weak: 5, medium: 3, strong: 1 }`
+- `COSTS = { weak: 1, medium: 3, strong: 6 }`
+- `FIRST_WEAK_FREE = true`
+- `isOrientationLocked(state, blockId)`
+- `isCellLocked(state, blockId)` → `{x, y} | null`
+- `isFullyLocked(state, blockId)`
+
+State shape (mutable, owned by gameScene per puzzle):
+```js
+{
+  puzzleId: 'YYYY-MM-DD:hard:c3',
+  // Per-block lock flags
+  weakLocked: { [blockId]: true },      // orientation locked
+  mediumLocked: { [blockId]: { x, y } }, // cell locked
+  strongLocked: { [blockId]: true },     // fully locked, no remove
+  // Usage counters (for cap enforcement)
+  usedWeak: 0,
+  usedMedium: 0,
+  usedStrong: 0,
+}
+```
+
+---
+
+## Task 1: Test infrastructure
+
+**Files:**
+- Create: `calendar-puzzle-miniprogram/package.json`
+- Create: `calendar-puzzle-miniprogram/tests/hint.test.js`
+
+- [ ] **Step 1: Write the failing test (sanity check that test runner works)**
+
+```js
+// calendar-puzzle-miniprogram/tests/hint.test.js
+var test = require('node:test');
+var assert = require('node:assert');
+
+test('test runner works', function () {
+  assert.strictEqual(1 + 1, 2);
+});
+```
+
+- [ ] **Step 2: Create package.json**
+
+```json
+{
+  "name": "calendar-puzzle-miniprogram-tests",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "node --test tests/"
+  }
+}
+```
+
+- [ ] **Step 3: Run test to verify infra works**
+
+Run: `cd calendar-puzzle-miniprogram && npm test`
+Expected: 1 passing test, exit code 0
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/package.json calendar-puzzle-miniprogram/tests/hint.test.js
+git commit -m "test(minigame): add node --test runner scaffold for hint state machine"
+```
+
+---
+
+## Task 2: Expose solvedPlacements from puzzleGenerator
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/puzzleGenerator.js:606-625` (module.exports block)
+
+- [ ] **Step 1: Verify current function exists and behavior**
+
+Run: `grep -n "_solvedPlacements" calendar-puzzle-miniprogram/minigame/js/puzzleGenerator.js`
+Expected: line ~434 defining `function _solvedPlacements(sb) { ... }`
+
+- [ ] **Step 2: Rename to `solvedPlacements` (remove underscore prefix) and add to exports**
+
+Edit `puzzleGenerator.js`: change `function _solvedPlacements(sb)` → `function solvedPlacements(sb)`. Update any internal callers in the same file (grep first).
+
+Run: `grep -n "_solvedPlacements" calendar-puzzle-miniprogram/minigame/js/puzzleGenerator.js`
+Expected: zero matches (all renamed). Then `grep "solvedPlacements"` should show the function def + internal callers + new export.
+
+Edit `module.exports` block to add `solvedPlacements: solvedPlacements,` alongside existing exports.
+
+- [ ] **Step 3: Smoke test the export from a node REPL**
+
+Run:
+```bash
+cd calendar-puzzle-miniprogram/minigame
+node -e "var PG = require('./js/puzzleGenerator'); console.log(typeof PG.solvedPlacements);"
+```
+Expected: `function`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/puzzleGenerator.js
+git commit -m "refactor(minigame): export solvedPlacements helper for hint module"
+```
+
+---
+
+## Task 3: hint.js skeleton + constants + state factory
+
+**Files:**
+- Create: `calendar-puzzle-miniprogram/minigame/js/hint.js`
+- Modify: `calendar-puzzle-miniprogram/tests/hint.test.js`
+
+- [ ] **Step 1: Write failing tests for `createHintState` + constants**
+
+Replace `tests/hint.test.js` with:
+```js
+var test = require('node:test');
+var assert = require('node:assert');
+var H = require('../minigame/js/hint');
+
+test('CAPS and COSTS are the agreed economy', function () {
+  assert.deepStrictEqual(H.CAPS, { weak: 5, medium: 3, strong: 1 });
+  assert.deepStrictEqual(H.COSTS, { weak: 1, medium: 3, strong: 6 });
+  assert.strictEqual(H.FIRST_WEAK_FREE, true);
+});
+
+test('createHintState returns fresh empty state', function () {
+  var s = H.createHintState('2026-05-18:hard:c3');
+  assert.strictEqual(s.puzzleId, '2026-05-18:hard:c3');
+  assert.deepStrictEqual(s.weakLocked, {});
+  assert.deepStrictEqual(s.mediumLocked, {});
+  assert.deepStrictEqual(s.strongLocked, {});
+  assert.strictEqual(s.usedWeak, 0);
+  assert.strictEqual(s.usedMedium, 0);
+  assert.strictEqual(s.usedStrong, 0);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd calendar-puzzle-miniprogram && npm test`
+Expected: FAIL with `Cannot find module '../minigame/js/hint'`
+
+- [ ] **Step 3: Implement skeleton**
+
+Create `calendar-puzzle-miniprogram/minigame/js/hint.js`:
+```js
+// 3-tier hint state machine. Pure JS — no wx.* calls. Tested with node --test.
+
+var CAPS = { weak: 5, medium: 3, strong: 1 };
+var COSTS = { weak: 1, medium: 3, strong: 6 };
+var FIRST_WEAK_FREE = true;
+
+function createHintState(puzzleId) {
+  return {
+    puzzleId: puzzleId,
+    weakLocked: {},
+    mediumLocked: {},
+    strongLocked: {},
+    usedWeak: 0,
+    usedMedium: 0,
+    usedStrong: 0,
+  };
+}
+
+function countUsed(state, type) {
+  if (type === 'weak') return state.usedWeak;
+  if (type === 'medium') return state.usedMedium;
+  if (type === 'strong') return state.usedStrong;
+  return 0;
+}
+
+function isOrientationLocked(state, blockId) {
+  return !!state.weakLocked[blockId] || !!state.strongLocked[blockId];
+}
+
+function isCellLocked(state, blockId) {
+  if (state.strongLocked[blockId]) return state.strongLocked[blockId]; // {x,y} stored
+  return state.mediumLocked[blockId] || null;
+}
+
+function isFullyLocked(state, blockId) {
+  return !!state.strongLocked[blockId];
+}
+
+module.exports = {
+  CAPS: CAPS,
+  COSTS: COSTS,
+  FIRST_WEAK_FREE: FIRST_WEAK_FREE,
+  createHintState: createHintState,
+  countUsed: countUsed,
+  isOrientationLocked: isOrientationLocked,
+  isCellLocked: isCellLocked,
+  isFullyLocked: isFullyLocked,
+};
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `cd calendar-puzzle-miniprogram && npm test`
+Expected: all tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/hint.js calendar-puzzle-miniprogram/tests/hint.test.js
+git commit -m "feat(minigame): hint.js skeleton with caps, costs, state factory"
+```
+
+---
+
+## Task 4: applyWeak — orientation lock + evict-from-board
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/hint.js`
+- Modify: `calendar-puzzle-miniprogram/tests/hint.test.js`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/hint.test.js`:
+```js
+function shapeEq(a, b) {
+  if (a.length !== b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i].length !== b[i].length) return false;
+    for (var j = 0; j < a[i].length; j++) if (a[i][j] !== b[i][j]) return false;
+  }
+  return true;
+}
+
+test('applyWeak updates palette block shape to solved orientation', function () {
+  var state = H.createHintState('p1');
+  var palette = [
+    { id: 'X-block', label: 'X', shape: [[1, 1], [0, 1]] },
+  ];
+  var dropped = [];
+  var solved = { 'X-block': { x: 0, y: 0, shape: [[0, 1], [1, 1]] } };
+
+  var res = H.applyWeak(state, 'X-block', palette, dropped, solved);
+
+  assert.ok(shapeEq(res.updatedPalette[0].shape, [[0, 1], [1, 1]]));
+  assert.strictEqual(res.newState.weakLocked['X-block'], true);
+  assert.strictEqual(res.newState.usedWeak, 1);
+  assert.deepStrictEqual(res.updatedDropped, []);
+});
+
+test('applyWeak evicts misplaced block from board back to palette', function () {
+  var state = H.createHintState('p1');
+  var palette = [];
+  var dropped = [
+    { id: 'X-block', label: 'X', shape: [[1, 1], [0, 1]], x: 3, y: 2 },
+  ];
+  var solved = { 'X-block': { x: 0, y: 0, shape: [[0, 1], [1, 1]] } };
+
+  var res = H.applyWeak(state, 'X-block', palette, dropped, solved);
+
+  assert.deepStrictEqual(res.updatedDropped, []);
+  assert.strictEqual(res.updatedPalette.length, 1);
+  assert.strictEqual(res.updatedPalette[0].id, 'X-block');
+  assert.ok(shapeEq(res.updatedPalette[0].shape, [[0, 1], [1, 1]]));
+  assert.strictEqual(res.updatedPalette[0].x, undefined);
+  assert.strictEqual(res.updatedPalette[0].y, undefined);
+});
+
+test('applyWeak keeps block on board if already in solved orientation', function () {
+  var state = H.createHintState('p1');
+  var palette = [];
+  var dropped = [
+    { id: 'X-block', label: 'X', shape: [[0, 1], [1, 1]], x: 0, y: 0 },
+  ];
+  var solved = { 'X-block': { x: 0, y: 0, shape: [[0, 1], [1, 1]] } };
+
+  var res = H.applyWeak(state, 'X-block', palette, dropped, solved);
+
+  assert.strictEqual(res.updatedDropped.length, 1);
+  assert.deepStrictEqual(res.updatedPalette, []);
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+Run: `cd calendar-puzzle-miniprogram && npm test`
+Expected: FAIL `H.applyWeak is not a function`
+
+- [ ] **Step 3: Implement `applyWeak`**
+
+Append to `hint.js` (above module.exports):
+```js
+function _shapeEq(a, b) {
+  if (!a || !b) return false;
+  if (a.length !== b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i].length !== b[i].length) return false;
+    for (var j = 0; j < a[i].length; j++) if (a[i][j] !== b[i][j]) return false;
+  }
+  return true;
+}
+
+function _cloneShape(s) {
+  return s.map(function (row) { return row.slice(); });
+}
+
+function _cloneBlock(b) {
+  var n = {};
+  for (var k in b) {
+    if (k === 'shape') n.shape = _cloneShape(b.shape);
+    else n[k] = b[k];
+  }
+  return n;
+}
+
+function applyWeak(state, blockId, palette, dropped, solvedPlacements) {
+  var target = solvedPlacements[blockId];
+  if (!target) return { newState: state, updatedPalette: palette, updatedDropped: dropped };
+
+  var newPalette = palette.map(_cloneBlock);
+  var newDropped = dropped.map(_cloneBlock);
+
+  // Find block on palette
+  for (var p = 0; p < newPalette.length; p++) {
+    if (newPalette[p].id === blockId) {
+      newPalette[p].shape = _cloneShape(target.shape);
+    }
+  }
+
+  // Find block on board; evict if shape doesn't match solved
+  for (var d = newDropped.length - 1; d >= 0; d--) {
+    if (newDropped[d].id === blockId) {
+      if (!_shapeEq(newDropped[d].shape, target.shape)) {
+        var ev = _cloneBlock(newDropped[d]);
+        ev.shape = _cloneShape(target.shape);
+        delete ev.x; delete ev.y;
+        newPalette.push(ev);
+        newDropped.splice(d, 1);
+      }
+      // already correctly oriented → leave it
+    }
+  }
+
+  var newState = {
+    puzzleId: state.puzzleId,
+    weakLocked: Object.assign({}, state.weakLocked, function () { var o = {}; o[blockId] = true; return o; }()),
+    mediumLocked: state.mediumLocked,
+    strongLocked: state.strongLocked,
+    usedWeak: state.usedWeak + 1,
+    usedMedium: state.usedMedium,
+    usedStrong: state.usedStrong,
+  };
+
+  return { newState: newState, updatedPalette: newPalette, updatedDropped: newDropped };
+}
+```
+
+Add `applyWeak: applyWeak,` to `module.exports`.
+
+- [ ] **Step 4: Run test, verify PASS**
+
+Run: `cd calendar-puzzle-miniprogram && npm test`
+Expected: all tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/hint.js calendar-puzzle-miniprogram/tests/hint.test.js
+git commit -m "feat(minigame): hint.applyWeak — orientation lock with evict"
+```
+
+---
+
+## Task 5: applyMedium — cell hint without revealing orientation
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/hint.js`
+- Modify: `calendar-puzzle-miniprogram/tests/hint.test.js`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/hint.test.js`:
+```js
+test('applyMedium records target cell, does NOT change palette shape', function () {
+  var state = H.createHintState('p1');
+  var palette = [{ id: 'X-block', label: 'X', shape: [[1, 1], [0, 1]] }];
+  var dropped = [];
+  var solved = { 'X-block': { x: 2, y: 3, shape: [[0, 1], [1, 1]] } };
+
+  var res = H.applyMedium(state, 'X-block', palette, dropped, solved);
+
+  assert.deepStrictEqual(res.hintedCell, { x: 2, y: 3 });
+  assert.ok(shapeEq(res.updatedPalette[0].shape, [[1, 1], [0, 1]])); // unchanged
+  assert.deepStrictEqual(res.newState.mediumLocked['X-block'], { x: 2, y: 3 });
+  assert.strictEqual(res.newState.usedMedium, 1);
+});
+
+test('applyMedium evicts board block placed at wrong cell', function () {
+  var state = H.createHintState('p1');
+  var palette = [];
+  var dropped = [{ id: 'X-block', label: 'X', shape: [[1, 1], [0, 1]], x: 0, y: 0 }];
+  var solved = { 'X-block': { x: 5, y: 5, shape: [[0, 1], [1, 1]] } };
+
+  var res = H.applyMedium(state, 'X-block', palette, dropped, solved);
+
+  assert.deepStrictEqual(res.updatedDropped, []);
+  assert.strictEqual(res.updatedPalette.length, 1);
+  assert.strictEqual(res.updatedPalette[0].x, undefined);
+});
+
+test('applyMedium leaves correctly-positioned block in place', function () {
+  var state = H.createHintState('p1');
+  var palette = [];
+  var dropped = [{ id: 'X-block', label: 'X', shape: [[1, 1], [0, 1]], x: 5, y: 5 }];
+  var solved = { 'X-block': { x: 5, y: 5, shape: [[0, 1], [1, 1]] } };
+
+  var res = H.applyMedium(state, 'X-block', palette, dropped, solved);
+
+  assert.strictEqual(res.updatedDropped.length, 1);
+  assert.strictEqual(res.updatedDropped[0].x, 5);
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+Run: `cd calendar-puzzle-miniprogram && npm test`
+Expected: FAIL `H.applyMedium is not a function`
+
+- [ ] **Step 3: Implement `applyMedium`**
+
+Append to `hint.js` (before module.exports):
+```js
+function applyMedium(state, blockId, palette, dropped, solvedPlacements) {
+  var target = solvedPlacements[blockId];
+  if (!target) return { newState: state, updatedPalette: palette, updatedDropped: dropped, hintedCell: null };
+
+  var newPalette = palette.map(_cloneBlock);
+  var newDropped = dropped.map(_cloneBlock);
+
+  for (var d = newDropped.length - 1; d >= 0; d--) {
+    if (newDropped[d].id === blockId) {
+      if (newDropped[d].x !== target.x || newDropped[d].y !== target.y) {
+        var ev = _cloneBlock(newDropped[d]);
+        delete ev.x; delete ev.y;
+        newPalette.push(ev);
+        newDropped.splice(d, 1);
+      }
+    }
+  }
+
+  var newMed = Object.assign({}, state.mediumLocked);
+  newMed[blockId] = { x: target.x, y: target.y };
+
+  var newState = {
+    puzzleId: state.puzzleId,
+    weakLocked: state.weakLocked,
+    mediumLocked: newMed,
+    strongLocked: state.strongLocked,
+    usedWeak: state.usedWeak,
+    usedMedium: state.usedMedium + 1,
+    usedStrong: state.usedStrong,
+  };
+
+  return { newState: newState, updatedPalette: newPalette, updatedDropped: newDropped, hintedCell: { x: target.x, y: target.y } };
+}
+```
+
+Add `applyMedium: applyMedium,` to `module.exports`.
+
+- [ ] **Step 4: Run test, verify PASS**
+
+Run: `cd calendar-puzzle-miniprogram && npm test`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/hint.js calendar-puzzle-miniprogram/tests/hint.test.js
+git commit -m "feat(minigame): hint.applyMedium — cell target without orientation"
+```
+
+---
+
+## Task 6: applyStrong — full lock with evict-blockers
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/hint.js`
+- Modify: `calendar-puzzle-miniprogram/tests/hint.test.js`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/hint.test.js`:
+```js
+test('applyStrong places block at solved location with solved shape', function () {
+  var state = H.createHintState('p1');
+  var palette = [{ id: 'X-block', label: 'X', shape: [[1, 1], [0, 1]] }];
+  var dropped = [];
+  var solved = { 'X-block': { x: 2, y: 3, shape: [[0, 1], [1, 1]] } };
+
+  var res = H.applyStrong(state, 'X-block', palette, dropped, solved);
+
+  assert.deepStrictEqual(res.updatedPalette, []);
+  assert.strictEqual(res.updatedDropped.length, 1);
+  assert.strictEqual(res.updatedDropped[0].id, 'X-block');
+  assert.strictEqual(res.updatedDropped[0].x, 2);
+  assert.strictEqual(res.updatedDropped[0].y, 3);
+  assert.ok(shapeEq(res.updatedDropped[0].shape, [[0, 1], [1, 1]]));
+  assert.strictEqual(res.newState.strongLocked['X-block'].x, 2);
+  assert.strictEqual(res.newState.usedStrong, 1);
+  assert.deepStrictEqual(res.evictedIds, []);
+});
+
+test('applyStrong evicts blockers that overlap the target', function () {
+  var state = H.createHintState('p1');
+  var palette = [{ id: 'X-block', label: 'X', shape: [[1, 1], [0, 1]] }];
+  // Y-block is currently placed and overlaps cell (2,3)
+  var dropped = [{ id: 'Y-block', label: 'Y', shape: [[1, 1]], x: 2, y: 3 }];
+  var solved = { 'X-block': { x: 2, y: 3, shape: [[0, 1], [1, 1]] } };
+
+  var res = H.applyStrong(state, 'X-block', palette, dropped, solved);
+
+  assert.deepStrictEqual(res.evictedIds, ['Y-block']);
+  // X-block placed
+  assert.strictEqual(res.updatedDropped.length, 1);
+  assert.strictEqual(res.updatedDropped[0].id, 'X-block');
+  // Y-block back in palette
+  assert.ok(res.updatedPalette.some(function (b) { return b.id === 'Y-block'; }));
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+Run: `cd calendar-puzzle-miniprogram && npm test`
+
+- [ ] **Step 3: Implement `applyStrong`**
+
+Append to `hint.js`:
+```js
+function _cellsOf(block) {
+  var cells = [];
+  for (var dy = 0; dy < block.shape.length; dy++) {
+    for (var dx = 0; dx < block.shape[dy].length; dx++) {
+      if (block.shape[dy][dx] === 1) cells.push({ x: block.x + dx, y: block.y + dy });
+    }
+  }
+  return cells;
+}
+
+function applyStrong(state, blockId, palette, dropped, solvedPlacements) {
+  var target = solvedPlacements[blockId];
+  if (!target) return { newState: state, updatedPalette: palette, updatedDropped: dropped, evictedIds: [] };
+
+  var newPalette = palette.map(_cloneBlock);
+  var newDropped = dropped.map(_cloneBlock);
+
+  // Cells that the target placement will occupy
+  var targetCells = _cellsOf({ x: target.x, y: target.y, shape: target.shape });
+  var occ = {};
+  for (var i = 0; i < targetCells.length; i++) occ[targetCells[i].x + ',' + targetCells[i].y] = true;
+
+  // Evict any dropped block (other than blockId) that overlaps
+  var evictedIds = [];
+  for (var d = newDropped.length - 1; d >= 0; d--) {
+    var b = newDropped[d];
+    if (b.id === blockId) {
+      newDropped.splice(d, 1); // remove old placement (will re-place)
+      continue;
+    }
+    var bCells = _cellsOf(b);
+    for (var c = 0; c < bCells.length; c++) {
+      if (occ[bCells[c].x + ',' + bCells[c].y]) {
+        var ev = _cloneBlock(b);
+        delete ev.x; delete ev.y;
+        newPalette.push(ev);
+        newDropped.splice(d, 1);
+        evictedIds.push(b.id);
+        break;
+      }
+    }
+  }
+
+  // Pull blockId out of palette if present
+  for (var p = newPalette.length - 1; p >= 0; p--) {
+    if (newPalette[p].id === blockId) newPalette.splice(p, 1);
+  }
+
+  // Place at solved position
+  newDropped.push({
+    id: blockId,
+    label: target.shape && target.shape.length ? blockId.charAt(0) : '',
+    shape: _cloneShape(target.shape),
+    x: target.x,
+    y: target.y,
+  });
+  // Pull label/extra fields from the original block if available
+  var sourceBlock = null;
+  for (var sp = 0; sp < palette.length; sp++) if (palette[sp].id === blockId) sourceBlock = palette[sp];
+  for (var sd = 0; sd < dropped.length; sd++) if (dropped[sd].id === blockId) sourceBlock = dropped[sd];
+  if (sourceBlock) {
+    var placed = newDropped[newDropped.length - 1];
+    for (var k in sourceBlock) {
+      if (k === 'shape' || k === 'x' || k === 'y') continue;
+      placed[k] = sourceBlock[k];
+    }
+  }
+
+  var newStrong = Object.assign({}, state.strongLocked);
+  newStrong[blockId] = { x: target.x, y: target.y };
+
+  var newState = {
+    puzzleId: state.puzzleId,
+    weakLocked: state.weakLocked,
+    mediumLocked: state.mediumLocked,
+    strongLocked: newStrong,
+    usedWeak: state.usedWeak,
+    usedMedium: state.usedMedium,
+    usedStrong: state.usedStrong + 1,
+  };
+
+  return { newState: newState, updatedPalette: newPalette, updatedDropped: newDropped, evictedIds: evictedIds };
+}
+```
+
+Add `applyStrong: applyStrong,` to `module.exports`.
+
+- [ ] **Step 4: Run test, verify PASS**
+
+Run: `cd calendar-puzzle-miniprogram && npm test`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/hint.js calendar-puzzle-miniprogram/tests/hint.test.js
+git commit -m "feat(minigame): hint.applyStrong — full lock with blocker evict"
+```
+
+---
+
+## Task 7: Cap enforcement and lock-check helpers
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/hint.js`
+- Modify: `calendar-puzzle-miniprogram/tests/hint.test.js`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/hint.test.js`:
+```js
+test('canUse returns false when cap reached', function () {
+  var s = H.createHintState('p1');
+  s.usedWeak = 5;
+  assert.strictEqual(H.canUse(s, 'weak'), false);
+  assert.strictEqual(H.canUse(s, 'medium'), true);
+});
+
+test('isOrientationLocked true after weak applied', function () {
+  var s = H.createHintState('p1');
+  var solved = { 'X-block': { x: 0, y: 0, shape: [[1]] } };
+  var r = H.applyWeak(s, 'X-block', [{ id: 'X-block', label: 'X', shape: [[1]] }], [], solved);
+  assert.strictEqual(H.isOrientationLocked(r.newState, 'X-block'), true);
+  assert.strictEqual(H.isOrientationLocked(r.newState, 'Y-block'), false);
+});
+
+test('isFullyLocked true after strong applied', function () {
+  var s = H.createHintState('p1');
+  var solved = { 'X-block': { x: 0, y: 0, shape: [[1]] } };
+  var r = H.applyStrong(s, 'X-block', [{ id: 'X-block', label: 'X', shape: [[1]] }], [], solved);
+  assert.strictEqual(H.isFullyLocked(r.newState, 'X-block'), true);
+});
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+Run: `cd calendar-puzzle-miniprogram && npm test`
+Expected: FAIL on `H.canUse is not a function`
+
+- [ ] **Step 3: Implement `canUse`**
+
+Append to `hint.js`:
+```js
+function canUse(state, type) {
+  return countUsed(state, type) < (CAPS[type] || 0);
+}
+```
+
+Add `canUse: canUse,` to `module.exports`.
+
+- [ ] **Step 4: Run test, verify PASS**
+
+Run: `cd calendar-puzzle-miniprogram && npm test`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/hint.js calendar-puzzle-miniprogram/tests/hint.test.js
+git commit -m "feat(minigame): hint.canUse cap enforcement"
+```
+
+---
+
+## Task 8: Refactor existing weak-hint path in gameScene to use hint.js
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/gameScene.js:7` (add require)
+- Modify: `calendar-puzzle-miniprogram/minigame/js/gameScene.js:54-55` (replace local hint state)
+- Modify: `calendar-puzzle-miniprogram/minigame/js/gameScene.js:1561-1597` (apply via module)
+- Modify: `calendar-puzzle-miniprogram/minigame/js/gameScene.js:1670-1692` (lock check via module)
+
+**Goal of this task:** Drop-in replace existing 弱-only hint with `hint.js`, **without** changing user-visible behavior. No cost, no menu, no caps yet — just the same free unlimited weak hint, but plumbed through the new state machine. This isolates the refactor risk from the feature additions.
+
+- [ ] **Step 1: Add require at top of gameScene.js**
+
+After line 8 (the `var progress = require('./progress');` line) add:
+```js
+var Hint = require('./hint');
+```
+
+- [ ] **Step 2: Replace local hint state declaration**
+
+Replace lines 54-55:
+```js
+var hintMode = false;
+var hintedIds = [];
+```
+with:
+```js
+var hintMode = false;
+var hintState = Hint.createHintState(
+  puzzle.dateStr + ':' + difficulty + ':c' + puzzle.currentComboIndex
+);
+var solvedPlacements = PG.solvedPlacements(puzzle.solvedBoard);
+```
+
+- [ ] **Step 3: Replace weak-hint apply block (around line 1561-1597)**
+
+Replace the body of the `if (hintMode) { ... }` block (the hit-test on `L.hintItems[hi3]`) with:
+```js
+if (hintMode) {
+  for (var hi3 = 0; hi3 < L.hintItems.length; hi3++) {
+    if (R.hitTest(x, y, L.hintItems[hi3])) {
+      var hBlock = L.hintItems[hi3].block;
+      if (Hint.isOrientationLocked(hintState, hBlock.id)) return;
+      var res = Hint.applyWeak(hintState, hBlock.id, palette, dropped, solvedPlacements);
+      hintState = res.newState;
+      palette = res.updatedPalette;
+      dropped = res.updatedDropped;
+      if (selected && selected.id === hBlock.id) {
+        // sync selected.shape from palette
+        for (var sp2 = 0; sp2 < palette.length; sp2++) {
+          if (palette[sp2].id === hBlock.id) selected.shape = palette[sp2].shape;
+        }
+      }
+      hintMode = false;
+      scene.dirty = true;
+      showToast('已提示 ' + hBlock.label + ' 的正确方向');
+      return;
+    }
+  }
+  if (L.hintCloseBtn && R.hitTest(x, y, L.hintCloseBtn)) { hintMode = false; scene.dirty = true; return; }
+  if (L.hintPopup && !R.hitTest(x, y, L.hintPopup)) { hintMode = false; scene.dirty = true; return; }
+  return;
+}
+```
+
+- [ ] **Step 4: Replace rotate/flip lock check (around line 1673, 1684)**
+
+Change:
+```js
+if (hintedIds.indexOf(selected.id) >= 0) { showToast('该方块方向已锁定'); return; }
+```
+to (both places):
+```js
+if (Hint.isOrientationLocked(hintState, selected.id)) { showToast('该方块方向已锁定'); return; }
+```
+
+- [ ] **Step 5: Replace isHinted check in render (around line 768)**
+
+Change:
+```js
+var isHinted = hintedIds.indexOf(item.block.id) >= 0;
+```
+to:
+```js
+var isHinted = Hint.isOrientationLocked(hintState, item.block.id);
+```
+
+- [ ] **Step 6: Replace alreadyHinted check in popup render (around line 825)**
+
+Change:
+```js
+var alreadyHinted = hintedIds.indexOf(ht.block.id) >= 0;
+```
+to:
+```js
+var alreadyHinted = Hint.isOrientationLocked(hintState, ht.block.id);
+```
+
+- [ ] **Step 7: Manual smoke test in WeChat DevTools**
+
+Open `calendar-puzzle-miniprogram/minigame/` in WeChat Developer Tools. Play any puzzle:
+- Tap 💡 → modal opens, all blocks selectable ✓
+- Tap a block → toast "已提示 X 的正确方向" ✓
+- Palette block's preview shows correct orientation ✓
+- Try to rotate the hinted block → toast "该方块方向已锁定" ✓
+- Misplaced block on board gets evicted back to palette ✓
+
+If any of the above fails, the refactor is broken — diagnose before continuing.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/gameScene.js
+git commit -m "refactor(minigame): route existing weak hint through hint.js state machine"
+```
+
+---
+
+## Task 9: 3-tier hint menu UI (弱/中/强 buttons with cost + cap badges)
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/gameScene.js:539-554` (popup layout)
+- Modify: `calendar-puzzle-miniprogram/minigame/js/gameScene.js:819-843` (popup render)
+- Modify: `calendar-puzzle-miniprogram/minigame/js/gameScene.js:1561-1597` (popup tap handling — new flow)
+
+**New UX**: tapping 💡 opens menu with 3 rows (弱/中/强), each showing cost + cap. Tapping a row → enters "select block" sub-mode for that tier → tapping a block applies that tier.
+
+State additions:
+```js
+var hintTier = null; // null | 'weak' | 'medium' | 'strong' — set when a tier is chosen, drives block-selection phase
+```
+
+- [ ] **Step 1: Add `hintTier` state next to `hintMode`**
+
+After existing `var hintMode = false;` (now line 54), insert:
+```js
+var hintTier = null;
+```
+
+- [ ] **Step 2: Rewrite hint-popup layout block**
+
+Replace the `if (hintMode) { ... L.hintItems ... }` layout block (around 539-554):
+```js
+if (hintMode) {
+  var popW = W * 0.78, popH = 240;
+  L.hintPopup = { x: (W - popW) / 2, y: (H - popH) / 2, w: popW, h: popH };
+
+  if (!hintTier) {
+    // Tier menu: 3 rows
+    L.hintTierBtns = [];
+    var rowH = 50, rowGap = 8;
+    var rowY = L.hintPopup.y + 50;
+    var tiers = ['weak', 'medium', 'strong'];
+    for (var ti = 0; ti < tiers.length; ti++) {
+      L.hintTierBtns.push({
+        x: L.hintPopup.x + 20, y: rowY + ti * (rowH + rowGap),
+        w: popW - 40, h: rowH, tier: tiers[ti],
+      });
+    }
+    L.hintItems = []; // not used in tier mode
+  } else {
+    // Block-selection mode (tier already chosen)
+    var candidates = [];
+    for (var ci2 = 0; ci2 < palette.length; ci2++) candidates.push(palette[ci2]);
+    for (var cj = 0; cj < dropped.length; cj++) candidates.push(dropped[cj]);
+    L.hintItems = [];
+    var hx = L.hintPopup.x + 20, hy = L.hintPopup.y + 50;
+    var hSize = 52, hGap = 10;
+    for (var hi = 0; hi < candidates.length; hi++) {
+      if (hx + hSize > L.hintPopup.x + L.hintPopup.w - 20) { hx = L.hintPopup.x + 20; hy += hSize + hGap; }
+      L.hintItems.push({ x: hx, y: hy, w: hSize, h: hSize, block: candidates[hi] });
+      hx += hSize + hGap;
+    }
+    L.hintTierBtns = [];
+  }
+  L.hintCloseBtn = { x: L.hintPopup.x + (popW - 90) / 2, y: L.hintPopup.y + popH - 46, w: 90, h: 34 };
+}
+```
+
+- [ ] **Step 3: Rewrite hint-popup render block (around 819-843)**
+
+Replace:
+```js
+if (hintMode && L.hintPopup) {
+  R.dim(ctx, W, H);
+  R.roundRect(ctx, L.hintPopup.x, L.hintPopup.y, L.hintPopup.w, L.hintPopup.h, 16, '#fff');
+
+  if (!hintTier) {
+    R.textBold(ctx, '选择提示等级', L.hintPopup.x + L.hintPopup.w / 2, L.hintPopup.y + 18, 17, '#333', 'center');
+    var tierLabels = {
+      weak:   '弱：揭示方向（旋转+镜像）',
+      medium: '中：揭示落点格子（不告诉方向）',
+      strong: '强：直接放置（自动腾位）',
+    };
+    var costLabels = {
+      weak:   Hint.COSTS.weak + ' 体力 / 关',
+      medium: Hint.COSTS.medium + ' 体力',
+      strong: Hint.COSTS.strong + ' 体力',
+    };
+    for (var ti2 = 0; ti2 < L.hintTierBtns.length; ti2++) {
+      var btn = L.hintTierBtns[ti2];
+      var used = Hint.countUsed(hintState, btn.tier);
+      var cap = Hint.CAPS[btn.tier];
+      var disabled = used >= cap;
+      var fill = disabled ? '#eee' : (btn.tier === 'strong' ? '#E53935' : btn.tier === 'medium' ? '#FB8C00' : BRAND);
+      R.roundRect(ctx, btn.x, btn.y, btn.w, btn.h, 8, fill);
+      R.text(ctx, tierLabels[btn.tier], btn.x + 12, btn.y + 8, 14, disabled ? '#999' : '#fff', 'left');
+      R.text(ctx, costLabels[btn.tier] + '  ' + used + '/' + cap, btn.x + 12, btn.y + 28, 11, disabled ? '#999' : 'rgba(255,255,255,0.85)', 'left');
+    }
+  } else {
+    R.textBold(ctx, '选择要提示的方块', L.hintPopup.x + L.hintPopup.w / 2, L.hintPopup.y + 18, 17, '#333', 'center');
+    for (var hi2 = 0; hi2 < L.hintItems.length; hi2++) {
+      var ht = L.hintItems[hi2];
+      var alreadyLocked = (hintTier === 'weak' && Hint.isOrientationLocked(hintState, ht.block.id))
+                       || (hintTier === 'medium' && Hint.isCellLocked(hintState, ht.block.id))
+                       || (hintTier === 'strong' && Hint.isFullyLocked(hintState, ht.block.id));
+      var blockFill = alreadyLocked ? '#ccc' : '#43A047';
+      R.roundRect(ctx, ht.x, ht.y, ht.w, ht.h, 6, blockFill);
+      R.text(ctx, ht.block.label, ht.x + ht.w / 2, ht.y + ht.h / 2 - 8, 18, '#fff', 'center');
+    }
+  }
+
+  R.button(ctx, L.hintCloseBtn.x, L.hintCloseBtn.y, L.hintCloseBtn.w, L.hintCloseBtn.h, hintTier ? '返回' : '取消', '#eee', '#333', 8);
+}
+```
+
+- [ ] **Step 4: Rewrite popup tap handler (around 1561-1597)**
+
+Replace existing `if (hintMode) { ... }` block:
+```js
+if (hintMode) {
+  // Tier selection
+  if (!hintTier && L.hintTierBtns) {
+    for (var tb = 0; tb < L.hintTierBtns.length; tb++) {
+      if (R.hitTest(x, y, L.hintTierBtns[tb])) {
+        var pickedTier = L.hintTierBtns[tb].tier;
+        if (Hint.countUsed(hintState, pickedTier) >= Hint.CAPS[pickedTier]) {
+          showToast('本关该提示已用完');
+          return;
+        }
+        var cost = Hint.COSTS[pickedTier];
+        var have = stamina.getStamina();
+        if (have < cost) {
+          showToast('体力不足！需要 ' + cost + ' 点，当前 ' + have);
+          return;
+        }
+        if (!stamina.consumeStamina(cost)) {
+          showToast('体力扣减失败');
+          return;
+        }
+        hintTier = pickedTier;
+        scene.dirty = true;
+        return;
+      }
+    }
+  }
+  // Block selection
+  if (hintTier) {
+    for (var hi3 = 0; hi3 < L.hintItems.length; hi3++) {
+      if (R.hitTest(x, y, L.hintItems[hi3])) {
+        var hBlock = L.hintItems[hi3].block;
+        var res;
+        if (hintTier === 'weak') {
+          if (Hint.isOrientationLocked(hintState, hBlock.id)) { showToast('该方块方向已提示过'); return; }
+          res = Hint.applyWeak(hintState, hBlock.id, palette, dropped, solvedPlacements);
+          showToast('已提示 ' + hBlock.label + ' 的正确方向');
+        } else if (hintTier === 'medium') {
+          if (Hint.isCellLocked(hintState, hBlock.id)) { showToast('该方块位置已提示过'); return; }
+          res = Hint.applyMedium(hintState, hBlock.id, palette, dropped, solvedPlacements);
+          showToast('已提示 ' + hBlock.label + ' 的落点');
+        } else {
+          if (Hint.isFullyLocked(hintState, hBlock.id)) { showToast('该方块已强提示'); return; }
+          res = Hint.applyStrong(hintState, hBlock.id, palette, dropped, solvedPlacements);
+          showToast('已为 ' + hBlock.label + ' 落子');
+        }
+        hintState = res.newState;
+        palette = res.updatedPalette;
+        dropped = res.updatedDropped;
+        if (selected) {
+          for (var sp3 = 0; sp3 < palette.length; sp3++) {
+            if (palette[sp3].id === selected.id) selected.shape = palette[sp3].shape;
+          }
+        }
+        hintMode = false;
+        hintTier = null;
+        scene.dirty = true;
+        return;
+      }
+    }
+  }
+  if (L.hintCloseBtn && R.hitTest(x, y, L.hintCloseBtn)) {
+    if (hintTier) {
+      // Refund stamina (user backed out of block selection)
+      // Note: a small leniency — they paid for the tier but didn't pick a block yet
+      // Decision: NO refund. Once tier is chosen, money's spent. Forces deliberate clicks.
+      hintTier = null;
+    } else {
+      hintMode = false;
+    }
+    scene.dirty = true; return;
+  }
+  if (L.hintPopup && !R.hitTest(x, y, L.hintPopup)) {
+    hintMode = false; hintTier = null; scene.dirty = true; return;
+  }
+  return;
+}
+```
+
+- [ ] **Step 5: Manual smoke test in DevTools**
+
+Verify:
+- 💡 button opens tier menu (3 rows: 弱/中/强) ✓
+- Each row shows cost (1/3/6) + used/cap (0/5, 0/3, 0/1) ✓
+- Picking 弱 with low stamina shows "体力不足" toast ✓
+- Picking 弱 with enough stamina deducts stamina, enters block selection ✓
+- Picking a block applies weak hint correctly ✓
+- 中 tier: block selection then no shape change on palette but board-cell highlighted (next task handles the highlight; for now verify no shape change) ✓
+- 强 tier: block placed at solved position with solved shape, blockers evicted ✓
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/gameScene.js
+git commit -m "feat(minigame): 3-tier hint menu (弱/中/强) with stamina cost + caps"
+```
+
+---
+
+## Task 10: Visual: medium-hint cell highlight on board
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/gameScene.js` — board render loop, add overlay for `Hint.isCellLocked` cells
+
+**Goal**: For each `mediumLocked` block, paint the target cell with the block's color at drag-preview opacity (~0.35). Also tap-on-cell shows toast naming the block.
+
+- [ ] **Step 1: Locate the board-cell render loop**
+
+Run: `grep -n "drawCellDecoration\|for.*cells\|board cell\|for.*y.*cells" calendar-puzzle-miniprogram/minigame/js/gameScene.js | head -20`
+
+The board is drawn with a nested loop iterating `r, c` from `0..rows`, `0..cols`. Find that loop (~line 600-700 range in render).
+
+- [ ] **Step 2: After the cell base draw, add medium-hint overlay**
+
+Inside the board cell loop (after `drawCellDecoration(ctx, cellType, px, py, cs)` call), add:
+```js
+// Medium-hint cell overlay (shows where a block should go, no orientation)
+for (var ml in hintState.mediumLocked) {
+  var mlc = hintState.mediumLocked[ml];
+  // The cell (mlc.x, mlc.y) is the block origin. We highlight ONLY the origin cell —
+  // user still doesn't know the shape. Adjust if origin cells feel too sparse.
+  if (mlc.x === c && mlc.y === r) {
+    // Find block color from palette/dropped (each block has a `color` field
+    // from initialBlockTypes; see board.js:15-24)
+    var blkColor = '#888';
+    for (var pp = 0; pp < palette.length; pp++) if (palette[pp].id === ml) blkColor = palette[pp].color || blkColor;
+    for (var dp = 0; dp < dropped.length; dp++) if (dropped[dp].id === ml) blkColor = dropped[dp].color || blkColor;
+    ctx.save();
+    ctx.globalAlpha = 0.35;
+    R.roundRect(ctx, px, py, cs, cs, 4, blkColor);
+    ctx.restore();
+  }
+}
+```
+
+
+- [ ] **Step 3: Manual smoke test in DevTools**
+
+- Apply a medium hint to block X
+- Board shows a translucent X-colored square at the hinted origin cell ✓
+- Switching puzzles clears the highlight (state recreated)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/gameScene.js
+git commit -m "feat(minigame): visual highlight for medium-hint target cell"
+```
+
+---
+
+## Task 11: Strong-locked block: reject double-click remove
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/gameScene.js` — double-tap-remove handler
+
+- [ ] **Step 1: Locate double-tap remove logic**
+
+Run: `grep -n "double.*tap\|lastTap\|double-click\|doubleTap" calendar-puzzle-miniprogram/minigame/js/gameScene.js | head -10`
+
+The double-tap detector compares `Date.now() - lastTap.time < N` and removes via `dropped = dropped.filter(...)` or similar. Find the exact removal site.
+
+- [ ] **Step 2: Before the remove, check `isFullyLocked`**
+
+Inside the double-tap branch, before the `dropped.filter(...)` call that removes the block:
+```js
+if (Hint.isFullyLocked(hintState, blockUnderTap.id)) {
+  wx.showModal({
+    title: '强提示锁定',
+    content: '这是强提示锁定的方块，不能移除。',
+    showCancel: false,
+  });
+  return;
+}
+```
+
+Substitute `blockUnderTap` with the actual variable name in scope (likely `b` or `placed` — read context to confirm).
+
+- [ ] **Step 3: Also reject drag-from-board for strong-locked blocks**
+
+Locate the drag-pickup-from-board logic (`grep -n "dragFromBoard\|getBlockAtCell" minigame/js/gameScene.js | head`).
+
+When a drag picks up a strong-locked block, abort:
+```js
+var pickedBlock = B.getBlockAtCell(dropped, gridX, gridY);
+if (pickedBlock && Hint.isFullyLocked(hintState, pickedBlock.id)) {
+  showToast('该方块由强提示锁定');
+  return;
+}
+```
+
+Insert this right after the `getBlockAtCell` call in the drag-start handler.
+
+- [ ] **Step 4: Manual smoke test**
+
+- Use strong hint on a block
+- Double-tap the placed block → modal "强提示锁定..." ✓
+- Try to drag the placed block → toast "该方块由强提示锁定", no movement ✓
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/gameScene.js
+git commit -m "feat(minigame): strong-locked block rejects remove and drag"
+```
+
+---
+
+## Task 12: Verify the existing first-tap behavior is `hintTier = null` (no regression)
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/gameScene.js` — `L.hintBtn` tap handler
+
+- [ ] **Step 1: Find hint button tap handler (around line 1695)**
+
+The handler currently sets `hintMode = true`. Confirm it also resets `hintTier = null`:
+```js
+if (L.hintBtn && R.hitTest(x, y, L.hintBtn)) {
+  hintMode = true;
+  hintTier = null; // ← ensure fresh menu on re-open
+  scene.dirty = true;
+  return;
+}
+```
+
+- [ ] **Step 2: Manual smoke test**
+
+- Open 💡 menu, pick 弱, back out via 返回
+- Open 💡 again → menu shows tier choices, not block selection ✓
+
+- [ ] **Step 3: Commit (only if a change was needed)**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/gameScene.js
+git commit -m "fix(minigame): reset hint tier when opening hint menu"
+```
+
+(Skip commit if no change was needed.)
+
+---
+
+## Task 13: End-to-end smoke test checklist (manual)
+
+Open the minigame in WeChat DevTools. For each of these scenarios, complete the action and verify the outcome. Note any failure as a follow-up bug, not a plan blocker.
+
+**Setup**: Start a "hard"-difficulty puzzle. Stamina = 120 (set by default after a fresh storage clear).
+
+- [ ] **Step 1: Weak hint full happy path**
+
+1. Tap 💡 → tier menu opens
+2. Tap 弱 → stamina drops from 120 to 119; block-selection mode
+3. Tap any unplaced block → toast "已提示 X 的正确方向"; that block's palette card shows the solved orientation; 旋转/翻转 按钮 click → toast "该方块方向已锁定" ✓
+
+- [ ] **Step 2: Medium hint full happy path**
+
+1. Tap 💡 → 中 → stamina 119 → 116
+2. Tap any block → toast "已提示 X 的落点"; board shows translucent colored square at the target origin cell ✓
+
+- [ ] **Step 3: Strong hint full happy path**
+
+1. Place 1-2 blocks wrong intentionally
+2. Tap 💡 → 强 → stamina 116 → 110
+3. Tap a block whose solved location overlaps your wrongly-placed blocks
+4. Wrongly-placed blocks bounce back to palette; target block appears at solved position with solved orientation ✓
+5. Try to double-tap the strong-locked block → modal "强提示锁定..." appears ✓
+6. Try to drag the strong-locked block → toast "该方块由强提示锁定", no movement ✓
+
+- [ ] **Step 4: Cap enforcement**
+
+1. Use 5 weak hints (one per block) → 6th attempt: 弱 row is greyed; click → toast "本关该提示已用完" ✓
+
+- [ ] **Step 5: Stamina-low rejection**
+
+1. Manually edit storage to set stamina to 1 (or use 119 hints worth)
+2. Tap 💡 → 强 → toast "体力不足！需要 6 点，当前 X" ✓
+
+- [ ] **Step 6: Puzzle switch resets hints**
+
+1. Apply 1 weak + 1 medium
+2. 切换到下一关 (随机/手选)
+3. New puzzle: 💡 menu shows 0/5, 0/3, 0/1 ✓ (no carryover)
+
+If all checklist items pass, mark Plan 1 complete and move to Plan 2.
+
+---
+
+## Self-review notes
+
+**Spec coverage** (against `2026-05-18-social-features-design.md`):
+- §4.1 economy: ✓ (Task 3 constants; Task 9 enforcement). Note: this plan only implements `stamina` source; `share`/`help`/`ad`/`helperGift` deferred to Plan 2.
+- §4.2 3-tier semantics: ✓ (Tasks 4, 5, 6)
+- §4.3 entry flow: ✓ (Task 9 — 3-row menu, cost shown, block selection sub-mode)
+- §4.4 compatibility: ✓ (Task 8 keeps rotate/flip lock check; Task 11 adds strong-lock rejection on remove/drag)
+- §3.3 hintGrants data model: **deferred to Plan 2** (no cloud yet; this plan uses in-memory state per puzzle)
+- §5-§7 (social, ads, anti-cheat, push): **all deferred to Plan 2/3**
+
+**Placeholder scan**: no TBD/TODO left in tasks (Plan 2/3 are clearly scoped as separate plans, not "TODO" within this plan).
+
+**Type consistency**: hint.js exports verified against gameScene.js usage:
+- `createHintState(puzzleId)` — used in Task 8 step 2
+- `applyWeak/Medium/Strong(state, blockId, palette, dropped, solvedPlacements)` — used in Task 9 step 4
+- `isOrientationLocked/isCellLocked/isFullyLocked(state, blockId)` — used in Tasks 8/9/10/11
+- `canUse(state, type)` — exposed but `gameScene` uses `countUsed >= CAPS` check directly; that's fine, both code paths work
+- `CAPS`, `COSTS`, `FIRST_WEAK_FREE` — used in Tasks 9 render

--- a/docs/superpowers/specs/2026-05-18-social-features-design.md
+++ b/docs/superpowers/specs/2026-05-18-social-features-design.md
@@ -1,0 +1,252 @@
+# Calendar Puzzle 小游戏 · 社交功能设计
+
+**Date**: 2026-05-18
+**Status**: Draft for review
+**Scope**: `calendar-puzzle-miniprogram/minigame/`
+
+## 1. 目标
+
+让目前纯本地、纯单机的小游戏获得三件事：
+
+- **A 留存**：玩家被关卡卡住时有"救场"路径，不直接流失
+- **B 拉新**：把分享变成有意义的获益动作，让链接接收者真的转化
+- **C 社交感**：好友间能看到彼此的进度和成绩
+
+非目标：竞速直播、关卡共创、自定义关、跨小程序数据互通。
+
+## 2. 范围摘要
+
+| 模块 | 状态 |
+|---|---|
+| 3 级 hint 系统（弱/中/强） | 新增 |
+| 体力 / 群分享 / 助力 / 激励视频广告 4 路获取 hint | 新增 |
+| 微信云开发后端（首次引入） | 新增 |
+| 互助型助力（helper 也得奖励） | 新增 |
+| 好友榜（单日单关）+ 无提示勋章 | 新增 |
+| `subscribeMessage` 助力通知 | 新增 |
+| 求救信号 / 复盘分享 / 周关 / 关卡赠送 | 不做（未来 spec） |
+
+## 3. 架构
+
+### 3.1 端 / 云分工
+
+```
+┌─────────────────── 微信小游戏（端）──────────────────┐
+│  minigame/js/                                        │
+│    hint.js          ← 新增：3 级提示状态机           │
+│    cloudClient.js   ← 新增：云函数 wrapper          │
+│    ads.js           ← 新增：激励视频广告封装         │
+│    leaderboard.js   ← 新增：好友榜 UI + 数据         │
+│    helperGift.js    ← 新增：助力 helper 落地页       │
+│    shareState.js    ← 改：加 inviter token + 助力 cb │
+│    gameScene.js     ← 改：嵌入 hint 按钮 + 触发      │
+│    stamina.js       ← 不变（被 hint.js 消费）        │
+└──────────────────────────────────────────────────────┘
+                       │  wx.cloud.callFunction
+                       ▼
+┌─────────────── 微信云开发（cloud/）──────────────────┐
+│  functions/                                          │
+│    login         首次入库 user                       │
+│    shareGroup    群分享验证 + 计数                   │
+│    helpInvite    助力链路（A 帮 B 助力的写入）       │
+│    grantHint     根据动作（分享/广告/助力）发券      │
+│    submitScore   通关时间提交 + 勋章判定             │
+│    friendsScore  拉好友榜（关系链 KV 桥）            │
+│  database/                                           │
+│    users         openid, nickname, createdAt         │
+│    hintGrants    每张券一行（审计 + 防并发）         │
+│    shareLog      openid, openGId, date（群去重）     │
+│    helpLog       inviter, helper, date（助力去重）   │
+│    scores        当日通关成绩 + 勋章                 │
+└──────────────────────────────────────────────────────┘
+```
+
+### 3.2 关键技术决策
+
+- **不引入 server.py**：solver 仍跑端上（`dlx.js`），云端只做数据/社交。两个后端解耦。
+- **登录态**：首次冷启动调 `login` 云函数。后续云函数通过 `CONTEXT.OPENID` 自动识别身份，端上不传 openid。
+- **同步 vs 异步**：
+  - 同步等响应：领取 hint、使用 hint、提交分数、群分享换券
+  - 异步：助力到账通知、leaderboard 刷新
+- **本地 cache + 云端 source of truth**：所有计数本地缓存用于秒级响应，但**领取 / 使用都必须走云函数**。云函数失败时使用动作直接拒绝（不允许"先扣本地等会儿补"，否则离线刷券）。
+
+### 3.3 hintGrants 数据模型
+
+每张 hint 券一行（不做 counter 加减，天然防并发，留审计 trail）：
+
+```js
+{
+  _id: 'auto',
+  openid: 'xxx',
+  type: 'weak' | 'medium' | 'strong',
+  source: 'free' | 'stamina' | 'share' | 'help' | 'ad' | 'helperGift',
+  grantedAt: ServerDate,
+  usedAt: null | ServerDate,
+  usedInPuzzle: null | 'YYYY-MM-DD:hard:c3',  // 关卡标识
+}
+```
+
+**每关上限判定**：查询 `usedInPuzzle == 当前关 && usedAt != null && type == X` 的记录数 ≥ 上限则拒绝使用。
+
+**每关上限**：弱 5、中 3、强 1。每关首次免费送 1 张弱券。
+
+## 4. Hint 系统详细
+
+### 4.1 经济参数
+
+| 提示 | 体力 | 群分享 | 助力 | 广告 | 每关上限 |
+|---|---|---|---|---|---|
+| 弱 | 1 | — | — | — | 5（首次免费） |
+| 中 | 3 | 1 次新群分享 | — | 1 广告 | 3 |
+| 强 | 6 | 1 次新群分享 | 2 人助力累计 | 1 广告 | 1 |
+
+价格定位参考：当前难度阶梯 easy 3 / medium 5 / hard 7 / expert 9 / insomnia 0，所以单 hint 必须 < 单关代价。
+
+### 4.2 3 级语义
+
+| 操作 | 弱（朝向锁） | 中（位置锁） | 强（完整锁） |
+|---|---|---|---|
+| 用户选块（未放置 + 已放置都可选） | ✓ | ✓ | ✓ |
+| 揭示信息 | 旋转角 + 镜像 | (x,y) 单格 | 旋转 + 镜像 + (x,y) |
+| 视觉表现 | 托盘中块旋转/镜像到目标姿态；旋转 / 镜像按钮禁用 | 棋盘目标格：drag-preview 透明度 + 该块颜色 | 直接落子动画；挡路块弹回托盘 |
+| 块已在棋盘但姿态/位置不对 | 拿回托盘 | 拿回托盘 | 不会发生 |
+| 撤销 | ✗ | ✗ | 双击触发 modal："强提示锁定，不能移除" |
+| 关切换 | 全部清空 | 全部清空 | 全部清空 |
+
+### 4.3 玩家进入 hint 的流程
+
+1. `gameScene.js` 顶部加 💡 圆按钮
+2. 点击 → 弹三选一菜单（弱 / 中 / 强），每行显示：剩余券数 + 本关已用/上限 + 不足时的获取入口
+3. 选了某档但没券 → 二级弹窗列出获取路径（"花 N 体力" / "群分享换" / "看广告" / "邀请好友助力"），按钮各自独立
+4. 拿到券立刻进入"选块阶段"：托盘所有块可点（弱）/ 加棋盘上的块也可点（中/强）
+5. 选块完成 → 应用 lock + 视觉提示
+
+### 4.4 与现有交互的兼容
+
+- 棋盘上已放置块的拖动逻辑不变；只在 lock flag 命中时阻止
+- 现有双击移除加 1 个前置判断：strong-locked 块走 modal 路径
+- 弱锁后用户再点旋转按钮 → `wx.showToast("提示已锁定方向")`
+- hint 菜单 0.5s 无操作自动收起
+
+## 5. 社交闭环
+
+### 5.1 群分享换中提示
+
+```
+玩家点"中提示"且无券，选"分享到群"
+  → wx.shareAppMessage({ withShareTicket: true })
+  → 微信回调 shareTicket
+  → wx.getShareInfo({ shareTicket }) → encryptedData + iv
+  → 云函数 shareGroup({ encryptedData, iv })
+      → 服务端解密拿 openGId
+      → shareLog 表查 { openid, openGId, today } 是否存在
+      → 不存在 → 插入 + grantHint(medium, 'share')
+      → 存在 → 返回"今天这个群已经分享过"
+  → 端上 toast + 刷新券数
+```
+
+**边界**：玩家如果分享给单个好友而非群，shareTicket 不返回；返回失败 toast"请分享到群聊"。
+
+### 5.2 助力链路（互助型）
+
+分享 query 形式：`?inviter=<openid>&t=<server-issued-token>`
+
+```
+helper 点链接 → 端上读 query → 云函数 helpInvite({ inviter, t })
+  → 校验 t 签名 + 防自助（inviter !== CONTEXT.OPENID）
+  → helpLog 表去重（inviter + helper + date 唯一）
+  → 通过 → 写 helpLog
+  → 给 inviter grantHint(strong, 'help')
+      （source='help' 的总数每累计 2 次触发 1 张强券）
+  → 给 helper grantHint(weak, 'helperGift') 1 张
+  → 返回 inviter 昵称 + 当前进度
+  → helper 端弹"已为某某助力 + 你获得 1 张弱提示"
+  → inviter 端：subscribeMessage 已订阅 → 推送通知；否则下次进 app 拉 helpLog 汇总展示
+```
+
+**Token 设计**：服务端 issue 一次，HMAC-SHA256(openid + dateStr + secret)，端上分享时带上，云函数验签后写入。防止伪造 inviter 给陌生人发助力。
+
+### 5.3 inviter 通知模式
+
+首次成为 inviter（在收到第一个助力之前）小游戏弹窗：
+"开启通知 → 每次助力第一时间知道"
+- 允许 → `wx.requestSubscribeMessage(['help-arrived-template-id'])` → 后续走推送
+- 拒绝 → 沉默累加 → 下次进 app 头部红点 + "你收到 N 次助力"卡片
+
+### 5.4 激励视频广告（甲方案：先用测试 ID）
+
+`ads.js` 封装 `wx.createRewardedVideoAd`，包含：
+- 测试 unitId 常量 + TODO 注释（流量主开通后改正式 ID）
+- `showRewardedAd(onSuccess, onFail)` 接口
+- `onClose.isEnded === true` 才回 success
+- 加载失败 / 用户关闭 / 不支持 createRewardedVideoAd（低版本基础库）→ 各自不同的 onFail 原因
+
+**广告成功后**：必须调云函数 `grantHint(type, 'ad')` 发券，端上不能直接发（防 jailcrack）。云端无法验证广告是否真看完，容忍此风险。
+
+**`grantHint` 网络失败的兜底**：广告看完了但 `grantHint` 调用失败 → 端上把"待补发券"写本地待重试队列 `pendingAdGrants[]`，下次 app 启动或网络恢复时重试，最多 3 次。重试期间 UI 显示"广告券到账中"。
+
+## 6. 好友榜 + 勋章
+
+### 6.1 完成关卡时
+
+```js
+// 端上
+submitScore({
+  dateStr, difficulty, combo,
+  timeMs,
+  hintsUsed: { weak: 0, medium: 1, strong: 0 }
+})
+```
+
+云函数 `submitScore`：
+- 校验 `timeMs >= 10000`（人类反应下限保护）
+- 计算 badges：`hintsUsed.weak + .medium + .strong === 0` → 含 `nohint` 勋章
+- 写入 scores 表
+- 同步写微信 KV：`wx.setUserCloudStorage({ KVDataList: [{ key: 'd_2026-05-18_hard', value: JSON.stringify({ timeMs, badges }) }] })`
+
+### 6.2 拉好友榜
+
+`leaderboard.js` 调用 `wx.getFriendCloudStorage({ keyList: ['d_2026-05-18_hard'] })` →
+返回授权过该数据的好友列表 + 各自的 KV value → 端上排序 + 渲染。
+
+UI：通关页 + 关切换页都有一个横向滚动卡片，每卡：头像 + 昵称 + 时间 + 勋章。
+
+### 6.3 勋章
+
+MVP 只有 1 个：`nohint`（无提示通关）。后续可加：`speedrun`（前 10%）、`streak3`（3 连）等，本 spec 不展开。
+
+## 7. 防作弊
+
+| 风险 | 缓解 |
+|---|---|
+| 端上改本地 hintGrants 缓存白嫖 | 使用 hint 时必须云函数验证；本地 cache 只是 UI |
+| 端上伪造时间提交 leaderboard | 云函数校验 `timeMs >= 10000`；后续可加方差检测 |
+| 同一玩家双设备互助 | 助力时校验 `inviter !== CONTEXT.OPENID` |
+| 群分享 / 助力链接伪造 | encryptedData 后端解密 + token HMAC 验签 |
+| 跳过广告拿券 | 容忍（无法服务端校验，普通用户成本高） |
+
+## 8. 测试策略
+
+| 测试 | 工具 | 触发 |
+|---|---|---|
+| hint 状态机 unit | 端上 JS + mock | npm test |
+| 云函数 unit | 云开发本地调试 + jest | manual / CI |
+| 分享 + 助力端到端 | 两台微信真机 | 发版前 smoke |
+| Solver 兼容（hint 揭示的姿态在某个解里） | 复用 `dlx.js` | npm test |
+| 广告流程 | 微信开发者工具 + 测试 unitId | manual |
+
+## 9. 推出顺序（不属于本 spec 的实现范围，仅供参考）
+
+1. 云开发环境 + login + grantHint + 端上 cloudClient 框架
+2. hint 状态机 + UI（先只支持体力 source）
+3. ads.js + 看广告换 hint
+4. shareGroup + 群分享换 hint
+5. helpInvite + helper 落地页 + 互助奖励
+6. subscribeMessage + 助力推送
+7. submitScore + 好友榜 + nohint 勋章
+
+## 10. 开放问题（待实现时确认）
+
+- 关卡标识 `usedInPuzzle` 格式以 `${dateStr}:${difficulty}:c${comboIndex}` 为准（与 `shareState.js` 现有 query 对齐）
+- subscribeMessage 模板 ID 需要在小游戏后台创建后填入 cloudClient
+- 流量主开通后正式 adUnitId 需要更新 `ads.js` 常量


### PR DESCRIPTION
## Summary

Plan 1 of a 3-plan series adding social/retention features to the WeChat mini-game. This PR is **client-only, stamina-source only** — cloud, ads, share-for-hint, help, and leaderboard come in Plans 2-3.

- Adds a new pure-JS `hint.js` state machine (13 unit tests, zero runtime deps, runs via `node --test`)
- Upgrades the existing single-tier weak hint to **3 tiers** (弱 / 中 / 强) with per-puzzle caps (5 / 3 / 1)
- Costs: 弱 1 / 中 3 / 强 6 stamina; **first weak hint per puzzle is free**
- New visuals: medium-hint highlights a translucent block-colored cell on the board; strong-hint auto-evicts blockers and animates them back to palette
- Strong-locked blocks reject both double-tap-remove (modal) and drag-pickup (toast), with the drag guard now firing on threshold-cross so there's no visual glitch

## Architecture

- `minigame/js/hint.js` — pure state machine, no `wx.*` calls, no IO. All apply functions return `{ newState, updatedPalette, updatedDropped, ... }`.
- `minigame/js/gameScene.js` — thin renderer + event router; delegates hint logic to `hint.js`. Stamina deduction happens at block-selection (not tier-pick), so backing out of the menu costs nothing.
- `puzzleGenerator.js` exposes the previously-private `solvedPlacements(sb)` helper.

Plan 2/3 hooks: `Hint.COSTS` and `Hint.CAPS` are mutable data; `hintState` carries no stamina/cloud fields. Adding share-for-hint, ad-grants, or cloud-backed counters in Plan 2 won't require changes to `hint.js`.

## Spec + Plan

- Spec: \`docs/superpowers/specs/2026-05-18-social-features-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-18-hint-system-plan1.md\`

## Test Plan

Automated (passing):
- [x] \`cd calendar-puzzle-miniprogram && npm test\` — 13/13 unit tests on hint.js (state factory, applyWeak/Medium/Strong, evict logic, cap enforcement)
- [x] \`node --check js/gameScene.js\` clean

Manual smoke (please verify in WeChat DevTools):
- [ ] **Weak hint**: 💡 → 弱 → tap a block → palette card rotates to solved orientation, rotate/flip buttons rejected with toast
- [ ] **Medium hint**: 💡 → 中 → tap a block → translucent colored square appears at target origin cell
- [ ] **Strong hint**: place 1-2 blocks wrong → 💡 → 强 → tap a block → wrong blocks bounce back to palette, target placed; double-tap shows modal, drag shows toast
- [ ] **First-weak-free**: 1st 弱 on a puzzle costs 0 stamina; 2nd weak costs 1
- [ ] **Cap exhaustion**: after 5 weak / 3 medium / 1 strong, that tier row visibly disabled; tap shows "本关该提示已用完"
- [ ] **Low stamina**: low stamina + 强 → "体力不足！需要 6 点，当前 X"; tier-pick alone does NOT deduct stamina
- [ ] **Back-out costs nothing**: 💡 → 强 → 返回 → stamina unchanged
- [ ] **Puzzle switch**: switch to next puzzle → 💡 menu shows 0/5, 0/3, 0/1 (state fully reset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)