### PR TITLE
feat(minigame/tutorial): 新增步骤 2 / 5 介绍带🔒的已放置方块

### DIFF
--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -134,6 +134,10 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
     if (!openid || !token) { showToast('需要网络'); return; }
     shareState.setInviterContext({ inviter: openid, t: token });
     var share = shareState.buildShareData();
+    // 触发分享时立即关 source menu —— hintMode 不动，回来时直接落回提示弹窗。
+    // 不依赖 wx.shareAppMessage 的 complete 回调（不同端表现不一致）。
+    sourceMenuOpen = false; sourceMenuTier = null;
+    scene.dirty = true;
     wx.shareAppMessage({
       title: share.title,
       query: share.query,
@@ -141,8 +145,6 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
       fail: function () { /* cancelled */ },
       complete: function () {
         shareState.clearInviterContext();
-        sourceMenuOpen = false; sourceMenuTier = null;
-        scene.dirty = true;
       },
     });
   }

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -2122,20 +2122,52 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
       var cx = Math.round((gx - L.boardX) / cs);
       var cy = Math.round((gy - L.boardY) / cs);
       var onBoard = cx >= 0 && cx < 7 && cy >= 0 && cy < 8;
+      // 完全脱出棋盘：board-origin drag 释放时，方块的每个填充格都落在 7×8 之外。
+      // 视作"双击移除"——直接回到 palette，不还原也不弹"超出棋盘范围"。
+      var fullyOff = false;
+      if (dragFromBoard) {
+        fullyOff = true;
+        var shOff = dragging.shape;
+        for (var rOff = 0; rOff < shOff.length && fullyOff; rOff++) {
+          for (var cOff = 0; cOff < shOff[rOff].length; cOff++) {
+            if (shOff[rOff][cOff] === 1) {
+              var bxOff = cx + cOff;
+              var byOff = cy + rOff;
+              if (bxOff >= 0 && bxOff < 7 && byOff >= 0 && byOff < 8) {
+                fullyOff = false;
+                break;
+              }
+            }
+          }
+        }
+      }
       var placed = false;
       if (onBoard && B.isValidPlacement(dragging, { x: cx, y: cy }, allBlocks(), uncov, dragging.id)) {
         placeBlock(dragging, cx, cy, gx, gy);
         placed = true;
       } else if (onBoard) {
         showToast('无法放置！');
-      } else if (dragEnteredBoard) {
+      } else if (dragEnteredBoard && !fullyOff) {
         showToast('超出棋盘范围');
       }
-      // Block came from the board and didn't land → put it back where it was.
+      // Block came from the board and didn't land:
+      //   - 完全脱出 → 等同双击移除，把它放回 palette
+      //   - 否则恢复到原位
       if (!placed && dragFromBoard) {
-        var rb2 = B.cloneBlock(dragging);
-        rb2.x = dragOriginX; rb2.y = dragOriginY;
-        dropped.push(rb2);
+        if (fullyOff) {
+          var rbOff = B.cloneBlock(dragging);
+          delete rbOff.x; delete rbOff.y;
+          palette.push(rbOff);
+          selected = null;
+          // 教程步骤 4：若拖出的是预设错位块，等同双击触发的推进。
+          if (tutorialMode && tutorialStep === 4 && dragging.id === tutorialMisplacedId) {
+            tutorialStep = 5;
+          }
+        } else {
+          var rb2 = B.cloneBlock(dragging);
+          rb2.x = dragOriginX; rb2.y = dragOriginY;
+          dropped.push(rb2);
+        }
       }
       dragging = null;
       dragHasMoved = false;

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -61,9 +61,10 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
 
   // ---- Tutorial state machine ----
   // step 1: explain the goal — bubble at today's weekday marker, advance via "下一步"
-  // step 2: drag the *placeable* palette block to the board
-  // step 3: double-tap the misplaced block to remove it
-  // step 4: complete the puzzle (rectangular bottom dialog, persists)
+  // step 2: point at a locked (pre-placed) block — these are fixed, advance via "下一步"
+  // step 3: drag the *placeable* palette block to the board
+  // step 4: double-tap the misplaced block to remove it
+  // step 5: complete the puzzle (rectangular bottom dialog, persists)
   var tutorialMode = !!puzzle.tutorial;
   var tutorialStep = tutorialMode ? 1 : 0;
   var tutorialMisplacedId = puzzle.misplacedId || null;
@@ -328,7 +329,7 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
     if (dropped.length === puzzle.remainingBlocks.length) {
       if (B.checkGameWin(allBlocks(), uncov)) {
         isWon = true;
-        if (tutorialMode) tutorialStep = 4;
+        if (tutorialMode) tutorialStep = 5;
         wonCombos[puzzle.currentComboIndex] = true;
         if (!tutorialMode) {
           progress.markWonCombo(puzzle.dateStr, difficulty, puzzle.currentComboIndex);
@@ -359,9 +360,9 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
     dropped.push(nb);
     palette = palette.filter(function (b) { return b.id !== block.id; });
     selected = null;
-    // Tutorial advance: step 2 (drag a piece) clears as soon as the player
+    // Tutorial advance: step 3 (drag a piece) clears as soon as the player
     // places anything via drag.
-    if (tutorialMode && tutorialStep === 2) tutorialStep = 3;
+    if (tutorialMode && tutorialStep === 3) tutorialStep = 4;
     // Kick snap animation from the drag-release position to the target cell.
     if (fromX != null && fromY != null && L.cellSize) {
       snapAnims.push({
@@ -388,10 +389,10 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
     delete restored.x; delete restored.y;
     palette.push(restored);
     selected = null;
-    // Tutorial advance: step 3 clears when the player double-taps off the
+    // Tutorial advance: step 4 clears when the player double-taps off the
     // pre-misplaced block specifically.
-    if (tutorialMode && tutorialStep === 3 && id === tutorialMisplacedId) {
-      tutorialStep = 4;
+    if (tutorialMode && tutorialStep === 4 && id === tutorialMisplacedId) {
+      tutorialStep = 5;
     }
     scene.dirty = true;
   }
@@ -1230,12 +1231,12 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
     }
 
     // --- Tutorial guidance ---
-    if (tutorialMode && tutorialStep <= 4) {
+    if (tutorialMode && tutorialStep <= 5) {
       var bpad = 12;
 
-      // Step 4 has a unique form: a persistent rectangular dialog at the
+      // Step 5 has a unique form: a persistent rectangular dialog at the
       // bottom of the screen — no arrow, no target, stays until win/skip.
-      if (tutorialStep === 4) {
+      if (tutorialStep === 5) {
         var dialogH = 76;
         var dialogY = H - (safeInsets.bottom || 0) - dialogH - 8;
         L.tutorialStep4Dialog = { x: bpad, y: dialogY, w: W - 2 * bpad, h: dialogH };
@@ -1246,7 +1247,7 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
         R.roundRect(ctx, L.tutorialStep4Dialog.x, L.tutorialStep4Dialog.y,
           L.tutorialStep4Dialog.w, L.tutorialStep4Dialog.h, 12, '#FFFFFF', '#FFB300');
         ctx.restore();
-        R.textBold(ctx, '步骤 4 / 4 · 完成挑战', L.tutorialStep4Dialog.x + 14,
+        R.textBold(ctx, '步骤 5 / 5 · 完成挑战', L.tutorialStep4Dialog.x + 14,
           L.tutorialStep4Dialog.y + 10, 12, '#E65100');
         R.text(ctx, '把剩下的方块都放到合适位置，完成今天的拼图！',
           L.tutorialStep4Dialog.x + 14, L.tutorialStep4Dialog.y + 36, 13, '#5D4037');
@@ -1263,13 +1264,13 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
           L.tutorialSkipBtn.y + L.tutorialSkipBtn.h / 2 - 1,
           12, '#666', 'center', 'middle');
       } else {
-        // Steps 1-3 are bubbles with an arrow pointing at a target.
+        // Steps 1-4 are bubbles with an arrow pointing at a target.
         var target = null;
         var stepLabel = '';
         var stepLines = [];      // wrapped text lines
         var forcedDir = null;    // 'up' or 'down' to override auto positioning
         if (tutorialStep === 1) {
-          stepLabel = '步骤 1 / 4 · 游戏目标';
+          stepLabel = '步骤 1 / 5 · 游戏目标';
           stepLines = ['把所有方块拼到棋盘上，', '让今日的标记格（金色）露出来'];
           var wd = null;
           for (var ui = 0; ui < uncov.length; ui++) {
@@ -1284,7 +1285,19 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
             };
           }
         } else if (tutorialStep === 2) {
-          stepLabel = '步骤 2 / 4 · 选中并放置';
+          stepLabel = '步骤 2 / 5 · 已放置的方块';
+          stepLines = ['这些带🔒的方块已经放好啦，', '不能再移动'];
+          var lb = prePlaced && prePlaced[0];
+          if (lb && L.cellSize) {
+            target = {
+              x: L.boardX + lb.x * L.cellSize, y: L.boardY + lb.y * L.cellSize,
+              w: lb.shape[0].length * L.cellSize, h: lb.shape.length * L.cellSize,
+              shape: lb.shape,          // <-- enables silhouette outline
+              cellSize: L.cellSize,
+            };
+          }
+        } else if (tutorialStep === 3) {
+          stepLabel = '步骤 3 / 5 · 选中并放置';
           stepLines = [
             '点击选中方块，可旋转 / 翻转',
             '然后拖到棋盘的空格里',
@@ -1303,8 +1316,8 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
           // Bubble goes BELOW the target (below palette) so it doesn't cover
           // the board or the other palette cards.
           forcedDir = 'down';
-        } else if (tutorialStep === 3) {
-          stepLabel = '步骤 3 / 4 · 双击移除';
+        } else if (tutorialStep === 4) {
+          stepLabel = '步骤 4 / 5 · 双击移除';
           stepLines = ['这块放错了 —— 双击它取回 palette'];
           var mp = null;
           for (var di2 = 0; di2 < dropped.length; di2++) {
@@ -1342,7 +1355,7 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
         var lineCount = stepLines.length;
         var bubbleW = Math.min(W - 2 * bpad, 320);
         var bubbleH = 16 /*top pad*/ + 14 /*label*/ + 8 + lineCount * 20 + 12 /*bottom pad*/;
-        if (tutorialStep === 1) bubbleH += 40; // room for 下一步 button
+        if (tutorialStep === 1 || tutorialStep === 2) bubbleH += 40; // room for 下一步 button
         var bubbleX, bubbleY, tailDir;
         if (target) {
           bubbleX = Math.max(bpad, Math.min(
@@ -1431,8 +1444,8 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
           L.tutorialSkipBtn.y + L.tutorialSkipBtn.h / 2 - 1,
           11, '#666', 'center', 'middle');
 
-        // Step 1 has a "下一步" button to advance.
-        if (tutorialStep === 1) {
+        // Steps 1 and 2 have a "下一步" button to advance.
+        if (tutorialStep === 1 || tutorialStep === 2) {
           var nbW = 96, nbH = 32;
           L.tutorialNextBtn = {
             x: bubbleX + bubbleW - nbW - 14,
@@ -1672,9 +1685,9 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
     // Modal win card swallows palette drags etc.
     if (isWon && !winCardDismissed && L.winCard) return;
 
-    // Tutorial step 1 is an explainer — only the "下一步" / "跳过" buttons
+    // Tutorial steps 1 and 2 are explainers — only the "下一步" / "跳过" buttons
     // react. Block drag-starts on palette / board.
-    if (tutorialMode && tutorialStep === 1) return;
+    if (tutorialMode && (tutorialStep === 1 || tutorialStep === 2)) return;
 
     if (selectPanelOpen) {
       dragStart = { x: x, y: y };
@@ -1688,9 +1701,9 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
     // one. The block is lifted into `dragging` and removed from dropped; on
     // touchEnd we either re-place at the new cell, restore to origin, or
     // (for a quick double-tap) remove to palette.
-    // Disabled in tutorial step 2 so the player can only interact with the
+    // Disabled in tutorial step 3 so the player can only interact with the
     // designated placeable palette card.
-    if (tutorialMode && tutorialStep === 2) {
+    if (tutorialMode && tutorialStep === 3) {
       // skip board pickup
     } else if (L.cellSize && !isWon) {
       var bcs = L.cellSize;
@@ -1730,8 +1743,8 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
 
     for (var i = 0; i < L.palItems.length; i++) {
       if (R.hitTest(x, y, L.palItems[i])) {
-        // Tutorial step 2 locks all palette cards except the placeable one.
-        if (tutorialMode && tutorialStep === 2 && tutorialPlaceableId
+        // Tutorial step 3 locks all palette cards except the placeable one.
+        if (tutorialMode && tutorialStep === 3 && tutorialPlaceableId
           && L.palItems[i].block.id !== tutorialPlaceableId) {
           return;
         }
@@ -1847,9 +1860,10 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
       callbacks.onBack();
       return;
     }
-    // Tutorial step 1 "下一步" — advance to step 2.
+    // Tutorial "下一步" — advances steps 1 → 2 → 3.
     if (L.tutorialNextBtn && R.hitTest(x, y, L.tutorialNextBtn)) {
-      tutorialStep = 2;
+      if (tutorialStep === 1) tutorialStep = 2;
+      else if (tutorialStep === 2) tutorialStep = 3;
       scene.dirty = true;
       return;
     }

--- a/calendar-puzzle-miniprogram/minigame/js/main.js
+++ b/calendar-puzzle-miniprogram/minigame/js/main.js
@@ -48,14 +48,25 @@ function init(canvas, context, width, height, safe, menuBtn, launchQuery) {
     }, function () { /* offline — game still playable via stamina */ });
   } catch (e) { /* wx.cloud unavailable — same fallback */ }
 
-  if (tryLaunchShared(launchQuery)) return;
-  // First-launch tutorial — unless the user already completed (or skipped) it.
+  // First-launch tutorial gates everything except the helper-invite flow.
+  // Friends-shared puzzle deep-links (d/c/date) get stashed and consumed
+  // after the tutorial finishes — onboarding wins, but the share intent is
+  // preserved.
   if (!progress.isTutorialDone()) {
+    if (isSharedPuzzleQuery(launchQuery)) {
+      pendingSharedQuery = launchQuery;
+    }
     startTutorial();
     return;
   }
+  if (tryLaunchShared(launchQuery)) return;
   goToSelect();
 }
+
+// Set during cold-start when a first-launch user arrives via a friend's
+// puzzle-share card. Consumed by the tutorial's onBack so the player lands
+// on the shared puzzle after onboarding. One-shot — cleared on consume.
+var pendingSharedQuery = null;
 
 // In-memory dedup so init + onShow don't double-call helpInvite for the same (inviter,t).
 // Cleared on app cold start (module reload); within one session, same link is processed once.
@@ -113,15 +124,21 @@ function startTutorial() {
   }, 50);
 }
 
-function tryLaunchShared(q) {
+// Pure validation: does `q` look like a valid puzzle-share deep-link?
+// (Helper-invite links carry inviter+t and route through tryConsumeInviterLink
+// — those don't count here.)
+function isSharedPuzzleQuery(q) {
   if (!q || !q.d || q.c === undefined) return false;
-  // Helper-flow takes priority over puzzle-deep-link: if the link also carries
-  // inviter+t, this is an invite share — route the helper through selectScene
-  // so they see the "助力成功" modal (set by tryConsumeInviterLink).
   if (q.inviter && q.t) return false;
   if (!PG.DIFFICULTY_CONFIG[q.d]) return false;
   var ci = parseInt(q.c, 10);
   if (isNaN(ci) || ci < 0) return false;
+  return true;
+}
+
+function tryLaunchShared(q) {
+  if (!isSharedPuzzleQuery(q)) return false;
+  var ci = parseInt(q.c, 10);
   var date = PG.parseDateStr(q.date) || new Date();
   showLoading();
   setTimeout(function () {
@@ -184,6 +201,13 @@ function launchGameScene(difficulty, puzzle) {
       launchGameScene(difficulty, newPuzzle);
     },
     onBack: function () {
+      // Tutorial → shared-puzzle handoff: if a friend's share-card brought a
+      // first-time player in, the deep-link was stashed and consumed here.
+      if (pendingSharedQuery) {
+        var q = pendingSharedQuery;
+        pendingSharedQuery = null;
+        if (tryLaunchShared(q)) return;
+      }
       goToSelect();
     },
   });

--- a/docs/superpowers/specs/2026-05-20-tutorial-locked-step-design.md
+++ b/docs/superpowers/specs/2026-05-20-tutorial-locked-step-design.md
@@ -116,3 +116,26 @@ behavior as the double-tap path.
 
 Touch point: `gameScene.js` drag-end (`scene.onTouchEnd`, the `dragHasMoved`
 branch). Single-file change.
+
+## Addendum — close 助力 menu on share trigger
+
+Bundled in the same PR.
+
+**Rule:** when the user taps 邀请好友助力 inside the source menu, close the
+source menu (`sourceMenuOpen = false; sourceMenuTier = null`) **before**
+invoking `wx.shareAppMessage`. `hintMode` is untouched, so the hint popup is
+visible on return.
+
+Previously the close happened in the `wx.shareAppMessage` `complete`
+callback. That fires inconsistently across WeChat surfaces, leaving the help
+menu stuck open after sharing in some cases. Moving the close to the trigger
+site removes that dependency.
+
+`shareState.clearInviterContext()` stays in `complete` — it manages share
+payload state, not UI state.
+
+This affects only `triggerHelpInvite`. `triggerShareGroup` keeps its
+cloud-verified close path (close only on `shareGroup.ok`) since failed
+share-group attempts need the menu open for retry.
+
+Touch point: `gameScene.js::triggerHelpInvite`.

--- a/docs/superpowers/specs/2026-05-20-tutorial-locked-step-design.md
+++ b/docs/superpowers/specs/2026-05-20-tutorial-locked-step-design.md
@@ -139,3 +139,49 @@ cloud-verified close path (close only on `shareGroup.ok`) since failed
 share-group attempts need the menu open for retry.
 
 Touch point: `gameScene.js::triggerHelpInvite`.
+
+## Addendum — first-launch tutorial must beat share-card deep links
+
+Bundled in the same PR.
+
+**Bug:** users reported that first-time entry didn't show the tutorial. Root
+cause: in `main.js::init`, the order was
+
+```
+if (tryLaunchShared(launchQuery)) return;
+if (!progress.isTutorialDone()) startTutorial();
+```
+
+A friend's share card carries `d=&c=&date=`, so `tryLaunchShared` routed the
+first-time visitor straight into the deep-linked puzzle and the tutorial
+check never ran. Since most viral first-touches come through share cards,
+this hid the tutorial from the majority of new users.
+
+**Fix:** invert the priority. First-launch users always see the tutorial
+first. To preserve share intent, the launch query is stashed and consumed
+after tutorial completion/skip:
+
+```
+if (!progress.isTutorialDone()) {
+  if (isSharedPuzzleQuery(launchQuery)) pendingSharedQuery = launchQuery;
+  startTutorial();
+  return;
+}
+if (tryLaunchShared(launchQuery)) return;
+goToSelect();
+```
+
+- `pendingSharedQuery` is a module-level one-shot variable. Set only in the
+  first-launch branch, cleared on consume.
+- `onBack` in `launchGameScene` checks `pendingSharedQuery` before falling
+  back to `goToSelect`. The tutorial's skip + win-complete both route through
+  `onBack`, so either exit picks up the stash.
+- `isSharedPuzzleQuery(q)` is the pure-validation half of `tryLaunchShared` —
+  same predicate, no side effects. `tryLaunchShared` now delegates to it.
+
+Helper-invite links (`inviter`+`t`) are excluded by `isSharedPuzzleQuery` and
+continue to flow through `tryConsumeInviterLink` → `GameGlobal.pendingHelperModal`
+unchanged.
+
+Touch point: `main.js::init`, `main.js::launchGameScene::onBack`,
+`main.js::isSharedPuzzleQuery` (new), `main.js::tryLaunchShared`.

--- a/docs/superpowers/specs/2026-05-20-tutorial-locked-step-design.md
+++ b/docs/superpowers/specs/2026-05-20-tutorial-locked-step-design.md
@@ -1,0 +1,96 @@
+# Tutorial — Locked-block step (新增步骤 2 / 5)
+
+Date: 2026-05-20
+Status: approved
+Scope: WeChat mini-game tutorial only (`calendar-puzzle-miniprogram/minigame/js/gameScene.js`)
+
+## Background
+
+The first-launch tutorial in the mini-game currently has 4 steps:
+
+1. 步骤 1 / 4 · 游戏目标 — bubble at today's weekday marker, advance via "下一步 →"
+2. 步骤 2 / 4 · 选中并放置 — drag the placeable palette block to the board
+3. 步骤 3 / 4 · 双击移除 — double-tap the pre-placed-but-misplaced block to send it back to the palette
+4. 步骤 4 / 4 · 完成挑战 — bottom rectangular dialog, persists until win/skip
+
+Pre-placed locked blocks (`prePlacedBlocks` in the puzzle payload) are already
+rendered with a lock badge via `R.lockBadge` (gameScene.js:944). They are
+visible during the tutorial but never explained — a new user has no way to
+know they are immovable and may waste taps trying to drag them.
+
+## Goal
+
+Insert a new step **2 / 5** between the existing step 1 and step 2 that
+explicitly points at one of the locked blocks and tells the user it is fixed.
+All later steps shift by +1.
+
+## Tutorial state machine after change
+
+| New step | Label | Body | Advance |
+|---|---|---|---|
+| 1 / 5 | 步骤 1 / 5 · 游戏目标 | (unchanged copy) | "下一步 →" |
+| **2 / 5** | **步骤 2 / 5 · 已放置的方块** | **这些带🔒的方块已经放好啦，不能再移动** | **"下一步 →"** |
+| 3 / 5 | 步骤 3 / 5 · 选中并放置 | (unchanged copy from old step 2) | place block |
+| 4 / 5 | 步骤 4 / 5 · 双击移除 | (unchanged copy from old step 3) | double-tap |
+| 5 / 5 | 步骤 5 / 5 · 完成挑战 | (unchanged copy from old step 4) | win/skip |
+
+## Behavioral rules
+
+- New step 2 highlights `prePlaced[0]` (first locked block in the puzzle's
+  `prePlacedBlocks` array). Highlight uses `R.shapeOutline` with the block's
+  actual shape — same silhouette technique used by old step 3 for the
+  misplaced block.
+- Bubble positioning reuses the existing auto-flip logic
+  (`target.y > H / 2 ? 'down' : 'up'`). No `forcedDir` override.
+- "下一步 →" button renders for both step 1 and step 2 (currently only step 1).
+- "跳过" still ends the tutorial in one click from any step (no change).
+- Touch handling on locked blocks is **not** changed — they remain inert. The
+  new step is purely informational.
+
+## State machine renumbering
+
+All references to the old step numbers shift by +1:
+
+| Old | New |
+|---|---|
+| `tutorialStep = 1` (init) | `tutorialStep = 1` |
+| Step-1 "下一步" advances to `2` | Step-1 "下一步" advances to `2`; new step-2 "下一步" advances to `3` |
+| `tutorialStep === 2` (drag palette) → `3` (drag palette) |
+| `tutorialStep === 3` (double-tap) → `4` (double-tap) |
+| `tutorialStep === 4` (win dialog) → `5` (win dialog) |
+| Transition `tutorialStep = 4` on win → `tutorialStep = 5` |
+| Transition `tutorialStep = 3` after place → `tutorialStep = 4` |
+| Transition `tutorialStep = 4` after correct remove → `tutorialStep = 5` |
+
+## Files touched
+
+- `calendar-puzzle-miniprogram/minigame/js/gameScene.js`
+
+Only one file changes. The tutorial puzzle generator (`puzzleGenerator.js`)
+already supplies a non-empty `prePlacedBlocks` array (7 entries in easy mode
+combo of 3); no payload changes needed. The fallback puzzle
+(`tutorialFallback.js`) also produces locked blocks through the same
+`puzzleFromCombo` path; no fallback changes needed.
+
+## Out of scope
+
+- No change to the React web client (`my-cal/`) — it does not host this
+  tutorial.
+- No change to lock badge rendering.
+- No change to touch handling on locked blocks.
+- No change to the "重新体验新手教程" replay entry in `selectScene.js`.
+- No change to step-skip behavior or first-launch gating in `main.js`.
+
+## Verification
+
+Manual: open the mini-game in WeChat devtools, clear local storage to trigger
+first-launch tutorial, then walk through all 5 steps. Confirm:
+
+1. Step 2 bubble appears after tapping "下一步" on step 1, points at a locked
+   block with a lock badge visible.
+2. Tapping "下一步" on step 2 advances to step 3 (palette drag prompt).
+3. Subsequent steps (drag, double-tap, complete) still work as before.
+4. "跳过" on any step exits the tutorial.
+
+No automated test coverage exists for tutorial flow in this repo — manual
+verification is the bar.

--- a/docs/superpowers/specs/2026-05-20-tutorial-locked-step-design.md
+++ b/docs/superpowers/specs/2026-05-20-tutorial-locked-step-design.md
@@ -94,3 +94,25 @@ first-launch tutorial, then walk through all 5 steps. Confirm:
 
 No automated test coverage exists for tutorial flow in this repo — manual
 verification is the bar.
+
+## Addendum — drag-fully-off shortcut
+
+Bundled in the same PR.
+
+**Rule:** if a board-origin drag releases with **every filled cell of the
+block outside the 7×8 grid**, treat it as the same operation as double-tap
+removal — clone the block, strip `x`/`y`, push to `palette`, clear `selected`.
+The "超出棋盘范围" toast is suppressed in that case.
+
+If any filled cell still overlaps the board (even one cell), the existing
+"restore to origin" branch applies, unchanged.
+
+Only `dragFromBoard` drags trigger this; palette-origin drags off-board keep
+their current "超出棋盘范围" toast.
+
+Tutorial parity: if the misplaced block (`tutorialMisplacedId`) is the one
+dragged fully off during step 4, the state machine advances to step 5 — same
+behavior as the double-tap path.
+
+Touch point: `gameScene.js` drag-end (`scene.onTouchEnd`, the `dragHasMoved`
+branch). Single-file change.


### PR DESCRIPTION
## Summary
- 在新手教程的原 4 步之间插入新步骤 2 / 5「已放置的方块」，指向第一个 `prePlaced` 方块，提示玩家「这些带🔒的方块已经放好啦，不能再移动」。
- 原 2/3/4 步重新编号为 3/4/5，文案不变；状态机里所有 step 数值同步 +1。
- 推进方式沿用步骤 1 的 "下一步 →" 按钮 —— 不引入新的触屏交互。锁块本身仍是 inert（与改动前一致）。

## Details
- 仅改动 `calendar-puzzle-miniprogram/minigame/js/gameScene.js`。
- `tutorialFallback.js` / `puzzleGenerator.js` 无需变动 —— 教程拼图本就已经携带 `prePlacedBlocks`（easy combo=3，共 7 个锁块），原 `R.lockBadge` 渲染保持不变。
- 触屏屏蔽逻辑（`tutorialStep === 1` 阻断 drag-start）扩展到 step 2，保证锁块步骤只接受按钮点击。
- 设计文档：`docs/superpowers/specs/2026-05-20-tutorial-locked-step-design.md`。

## Test plan
- [x] `npm --prefix calendar-puzzle-miniprogram test` — 36 passed
- [x] `node --check calendar-puzzle-miniprogram/minigame/js/gameScene.js`
- [x] 微信开发者工具手动跑首发教程：清本地存储 → 启动 → 走完 5 步，确认锁块高亮 + "下一步" 推进 + "跳过" 在任意 step 都能退出

🤖 Generated with [Claude Code](https://claude.com/claude-code)