### PR TITLE
fix(minigame/helpInvite): 把 err 码暴露到 toast 让线上助力失败可自诊断

### DIFF
--- a/calendar-puzzle-miniprogram/minigame/js/main.js
+++ b/calendar-puzzle-miniprogram/minigame/js/main.js
@@ -100,10 +100,14 @@ function tryConsumeInviterLink(q) {
       };
       goToSelect();
     } else {
+      var errCode = (r && r.err) || 'unknown';
       var msg = ({
         'self-help': '不能给自己助力',
-        'bad-token': '链接无效',
-      })[r && r.err] || '助力失败';
+        'bad-token': '链接无效或已过期',
+        'invalid-input': '链接信息缺失',
+        'server-misconfigured': '助力服务暂不可用',
+        'log-failed': '助力失败（网络）',
+      })[errCode] || ('助力失败：' + errCode);
       if (typeof wx !== 'undefined' && wx.showToast) {
         wx.showToast({ title: msg, icon: 'none', duration: 2000 });
       }


### PR DESCRIPTION
## Summary

线上 0.4.0 报"助力失败"，定位过程靠猜（最后发现是 \`HELP_TOKEN_SECRET\` 漏配在 \`helpInvite\` 云函数）。改一行让 toast 直接显示底层 err 码，下次再有类似问题用户截图就能直接定位。

## 改动

\`main.js\` 的 \`tryConsumeInviterLink\` 兜底文案：

| err 码 | 旧文案 | 新文案 |
|---|---|---|
| \`self-help\` | 不能给自己助力 | 不能给自己助力 |
| \`bad-token\` | 链接无效 | 链接无效或已过期 |
| \`invalid-input\` | 助力失败 | 链接信息缺失 |
| \`server-misconfigured\` | 助力失败 | 助力服务暂不可用 |
| \`log-failed\` | 助力失败 | 助力失败（网络） |
| 未来未知 err | 助力失败 | **助力失败：<errCode>** |

\`helpInvite\` 云函数代码不变。

## Test plan

- [x] 195/195 单测保持绿
- [ ] 真机：故意把 \`HELP_TOKEN_SECRET\` 移到不一致状态 → 别人点助力链接 → toast 应该是"链接无效或已过期"（之前是含糊的"助力失败"）

🤖 Generated with [Claude Code](https://claude.com/claude-code)