### PR TITLE
feat(minigame): 0.6.0 medium-hint mismatch dialog + 0.7.0 hardcore mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ ssl/nginx.key
 .vscode/settings.json
 .spec-workflow/session.json
 .worktrees/
+
+# Visual brainstorming companion
+.superpowers/

--- a/calendar-puzzle-miniprogram/minigame/CHANGELOG.md
+++ b/calendar-puzzle-miniprogram/minigame/CHANGELOG.md
@@ -2,25 +2,37 @@
 
 ## [0.7.0] — 2026-05-27
 
+> 硬核模式 — 一键关掉所有辅助（提示 / 换题 / 重开），换"全凭脑子"的专注挑战。可叠加在 5 档已有难度上；通关解锁 "🔥 硬核通关" 标识，按日期 + 难度记录战绩。
+
 ### Added
-- 硬核模式开关（`selectScene` 难度按钮下方一行，🔥 toggle，本地持久化 storage key `calendarPuzzleHardcoreOn`，退到菜单保留上次状态）。开启后任何底层难度均进入硬核局。
-- 暂停菜单 ☰（顶栏右上）半屏 sheet — MVP 三条：`🔥 放弃硬核`（仅硬核局可见，单向降级）、`🏠 返回首页`、当前题面只读信息。
-- 通关结算页"🔥 硬核通关"标签（仅硬核局展示）。
+- **硬核开关**（`selectScene` 难度按钮下方一行，🔥 toggle，本地持久化 storage key `calendarPuzzleHardcoreOn`，重启小游戏保留上次状态）。开启后任何底层难度均进入硬核局。
+- **游戏内暂停菜单**：左下角 ☰ 按钮（避开微信胶囊菜单），点开弹出锚定 popover（不占半屏，游戏 UI 仍可见）。MVP 三条：`🔥 放弃硬核`（仅硬核局可见，单向降级 + 二次确认）、`🏠 返回首页`、当前题面只读信息。
+- **通关结算页 "🔥 硬核通关" 标签**（仅硬核局展示），结算卡自动加高 24px 防遮挡。
+- **存档列表 🔥 badge**：继续游戏 / 槽位选择 / 覆盖确认 / 未完成对局四处难度后追加 🔥，一眼区分硬核存档。
 - `progress.hardcoreDays` 持久化每日每难度的硬核通关记录（storage key `calendarPuzzleHardcoreDays`）。
-- `mode.js` 模块：mode 对象 + capability helpers（`canUseHint` / `canSwapPuzzle` / `canRestart` / `canClearBoard`），未来扩展模式的容器。
+- `mode.js` 模块：mode 对象 + capability helpers（`canUseHint` / `canSwapPuzzle` / `canRestart` / `canClearBoard`），未来扩展模式（限时、每日挑战…）的统一容器。
 
 ### Changed
 - 硬核局控制行折叠为 1 个按钮 "🧹 清空"（替代 "↺ 重开"），**清空时计时器不重置**；提示、🎲 随机、🎯 选题在硬核局不渲染。
-- 存档 slot payload 新增 `mode: { hardcore: bool }` 字段；老存档无此字段自动视作非硬核（向后兼容，无需迁移）。
+- 存档 slot payload 新增 `mode: { hardcore: bool }` 字段；老存档无此字段自动视作非硬核（向后兼容，无需迁移脚本）。
 - `createGameScene(...)` 入参增加第 7 位 `modeOpts`；`selectScene` `onSelect(difficulty, savedState, modeOpts)`；`main.js` 三层透传。
+
+### Fixed
+- `gameScene.js` `padBottom` ReferenceError — ☰ 按钮位置误引用了 `computeLayout` 内的局部变量，改用闭包绑定的 `safeInsets.bottom`（与帮助弹窗、胜利卡片的写法一致）。
 
 ### Tests
 - 新 `tests/mode.test.js`：mode 模块全分支（7 用例）。
 - 新 `tests/progress.hardcore.test.js`：hardcoreDays 持久化 + 幂等 + 跨难度并存 + storage round-trip（5 用例）。
 - `tests/slotStore.test.js` +2：`mode` 字段 round-trip + 老 payload 无字段回读。
+- `npm test` 总数 234 → 248（+14），全绿。
 
 ### Manual verification required (真机 / 微信开发者工具)
 - 见 `docs/superpowers/specs/2026-05-27-hardcore-mode-design.md` §6.2 (1-8)。
+- 额外验证：
+  - ☰ 按钮在左下角不撞胶囊菜单 + popover 锚定 ☰ 上方弹出，点 ☰ 外任意位置关闭。
+  - 存档列表硬核局难度后显示 🔥；非硬核老存档无此后缀。
+  - 硬核开关重启小游戏后保留上次 ON/OFF 状态。
+  - 硬核 expert 通关 → 结算页 "🔥 硬核通关" 不与时间行重叠。
 
 ## [0.6.0] — 2026-05-27
 

--- a/calendar-puzzle-miniprogram/minigame/CHANGELOG.md
+++ b/calendar-puzzle-miniprogram/minigame/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.7.0] — 2026-05-27
+
+### Added
+- 硬核模式开关（`selectScene` 难度按钮下方一行，🔥 toggle，per-session 不持久）。开启后任何底层难度均进入硬核局。
+- 暂停菜单 ☰（顶栏右上）半屏 sheet — MVP 三条：`🔥 放弃硬核`（仅硬核局可见，单向降级）、`🏠 返回首页`、当前题面只读信息。
+- 通关结算页"🔥 硬核通关"标签（仅硬核局展示）。
+- `progress.hardcoreDays` 持久化每日每难度的硬核通关记录（storage key `calendarPuzzleHardcoreDays`）。
+- `mode.js` 模块：mode 对象 + capability helpers（`canUseHint` / `canSwapPuzzle` / `canRestart` / `canClearBoard`），未来扩展模式的容器。
+
+### Changed
+- 硬核局控制行折叠为 1 个按钮 "🧹 清空"（替代 "↺ 重开"），**清空时计时器不重置**；提示、🎲 随机、🎯 选题在硬核局不渲染。
+- 存档 slot payload 新增 `mode: { hardcore: bool }` 字段；老存档无此字段自动视作非硬核（向后兼容，无需迁移）。
+- `createGameScene(...)` 入参增加第 7 位 `modeOpts`；`selectScene` `onSelect(difficulty, savedState, modeOpts)`；`main.js` 三层透传。
+
+### Tests
+- 新 `tests/mode.test.js`：mode 模块全分支（7 用例）。
+- 新 `tests/progress.hardcore.test.js`：hardcoreDays 持久化 + 幂等 + 跨难度并存 + storage round-trip（5 用例）。
+- `tests/slotStore.test.js` +2：`mode` 字段 round-trip + 老 payload 无字段回读。
+
+### Manual verification required (真机 / 微信开发者工具)
+- 见 `docs/superpowers/specs/2026-05-27-hardcore-mode-design.md` §6.2 (1-8)。
+
 ## [0.6.0] — 2026-05-27
 
 > 中提示位置违规检测 — drop 后如果跟中提示对不上，弹个对话框让玩家立刻取回重选。

--- a/calendar-puzzle-miniprogram/minigame/CHANGELOG.md
+++ b/calendar-puzzle-miniprogram/minigame/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [0.6.0] — 2026-05-27
+
+> 中提示位置违规检测 — drop 后如果跟中提示对不上，弹个对话框让玩家立刻取回重选。
+
+### 改动一览
+
+- **中提示不一致对话框**：drop 后如果（a）刚放的方块占了别的方块的中提示位，或（b）刚放的方块是被中提示的那一块但没盖全提示位，弹一个白底圆角对话框。主按钮「取回并重新选中」一键撤回 + 自动选中那块；次级文字按钮「本局不再提示」整局闭嘴；右上角 × 仅关闭这次（下次再违规还弹）。
+- **跨重载**：「本局不再提示」状态搭车 `hintState.mediumMismatchIgnored` 走存档；同一道题恢复后继续闭嘴，换题或新开局自动重置。
+
+### 详情
+
+- `hint.js` 新增纯函数 `findMediumMismatch(state, blockId, blockCells)` + `setMediumMismatchIgnored(state)`，检测逻辑优先级：自己有中提示但没盖全 → `right-block-wrong-loc`；别的块的中提示位被占 → `wrong-block-on-hint`；都没命中返回 null。一次 drop 最多弹一次（找到第一个违规就返回）。
+- `gameScene.js` `placeBlock` 末尾、`checkWin` 之前插入检测调用；触发时模态层渲染对话框、tap handler 接管所有点击直到关闭。modal state 是 in-memory（`var mediumMismatchModal = null`），不参与存档；`hintState.mediumMismatchIgnored` 持久。
+- `restoreHintState` 兜底新字段：缺字段 → 默认 `false`，向后兼容历史存档。`applyWeak`/`applyMedium`/`applyStrong` 全部转写新字段，避免下一次提示把 ignored 状态吃掉。
+
+### 测试
+
+- `tests/hint.test.js` +13 用例：`createHintState` 字段默认、`restoreHintState` 缺字段 / `true` round-trip、`applyWeak/Medium/Strong` 各自的字段保留回归、`findMediumMismatch` 全分支（null / right-block / wrong-block / 优先级 / blockCells null/空 / 不受 mediumMismatchIgnored 影响）、`setMediumMismatchIgnored` 不可变性。
+- `npm test` → **234/234 pass**。
+- gameScene 模态渲染 + tap：无单元测试 harness，手测路径见下方。
+
+### 手测路径
+
+1. 任意题打开 → 用中提示在 A 块上揭一格 → 把 B 块（≠ A）拖到那一格 → 对话框弹出，文案带两个块的 mini-icon → 点「取回并重新选中」→ B 块回 palette 并自动选中。
+2. 同上揭 A 块一格 → A 块拖到别处（没盖到提示位）→ 对话框弹「你刚把 A 放到了别的位置」→ 关 × → 下次再这样放还弹。
+3. 同上揭 A 块一格 → B 块拖到提示位 → 点「本局不再提示」→ 之后再随便错放都不弹 → 退游戏 → 从存档恢复 → 错放还是不弹。换题或新开局后恢复弹。
+4. 教程模式 / 存档 `initialDropped` 自动放置不走 `placeBlock` → 不弹。
+
 ## [0.5.5] — 2026-05-25
 
 > 退出时自动占用第一个空的命名槽位，避免新对局沉到临时槽里被下次会话遗忘。

--- a/calendar-puzzle-miniprogram/minigame/CHANGELOG.md
+++ b/calendar-puzzle-miniprogram/minigame/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [0.7.0] — 2026-05-27
 
 ### Added
-- 硬核模式开关（`selectScene` 难度按钮下方一行，🔥 toggle，per-session 不持久）。开启后任何底层难度均进入硬核局。
+- 硬核模式开关（`selectScene` 难度按钮下方一行，🔥 toggle，本地持久化 storage key `calendarPuzzleHardcoreOn`，退到菜单保留上次状态）。开启后任何底层难度均进入硬核局。
 - 暂停菜单 ☰（顶栏右上）半屏 sheet — MVP 三条：`🔥 放弃硬核`（仅硬核局可见，单向降级）、`🏠 返回首页`、当前题面只读信息。
 - 通关结算页"🔥 硬核通关"标签（仅硬核局展示）。
 - `progress.hardcoreDays` 持久化每日每难度的硬核通关记录（storage key `calendarPuzzleHardcoreDays`）。

--- a/calendar-puzzle-miniprogram/minigame/CHANGELOG.md
+++ b/calendar-puzzle-miniprogram/minigame/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### 测试
 
-- `tests/hint.test.js` +13 用例：`createHintState` 字段默认、`restoreHintState` 缺字段 / `true` round-trip、`applyWeak/Medium/Strong` 各自的字段保留回归、`findMediumMismatch` 全分支（null / right-block / wrong-block / 优先级 / blockCells null/空 / 不受 mediumMismatchIgnored 影响）、`setMediumMismatchIgnored` 不可变性。
+- `tests/hint.test.js` +14 用例：`createHintState` 字段默认、`restoreHintState` 缺字段 / `true` round-trip、`applyWeak/Medium/Strong` 各自的字段保留回归、`findMediumMismatch` 全分支（null / right-block / wrong-block / 优先级 / blockCells null/空 / 不受 mediumMismatchIgnored 影响）、`setMediumMismatchIgnored` 不可变性。
 - `npm test` → **234/234 pass**。
 - gameScene 模态渲染 + tap：无单元测试 harness，手测路径见下方。
 

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -123,6 +123,7 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
 
   // ---- Pause-menu state ----
   var pauseMenuOpen = false;
+  var abandonConfirmOpen = false;
 
   // ---- Save-slot modal state ----
   var slotModal = null;               // null | 'save-picker' | 'overwrite-warning'
@@ -1977,9 +1978,45 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
       R.roundRect(ctx, 0, sheetY, W, sheetH, 18, '#fff');
       R.textBold(ctx, '菜单', W / 2, sheetY + 28, 18, '#333', 'center', 'middle');
       L.pauseSheet = { x: 0, y: sheetY, w: W, h: sheetH };
-      // Entries rendered in Task 7. This block leaves a blank pane for now.
+      var rowH = 56, rowGap = 8;
+      var rowX = 16, rowY = sheetY + 60, rowW = W - 32;
+
+      L.pauseRowAbandon = null;
+      if (M.isHardcore(mode)) {
+        R.roundRect(ctx, rowX, rowY, rowW, rowH, 12, '#FFF3E0');
+        R.textBold(ctx, '🔥 放弃硬核', rowX + 16, rowY + rowH / 2, 16, '#E64A19', 'left', 'middle');
+        L.pauseRowAbandon = { x: rowX, y: rowY, w: rowW, h: rowH };
+        rowY += rowH + rowGap;
+      }
+
+      R.roundRect(ctx, rowX, rowY, rowW, rowH, 12, '#F5F5F5');
+      R.textBold(ctx, '🏠 返回首页', rowX + 16, rowY + rowH / 2, 16, '#333', 'left', 'middle');
+      L.pauseRowBack = { x: rowX, y: rowY, w: rowW, h: rowH };
+      rowY += rowH + rowGap;
+
+      // Read-only title block
+      var difficultyLabel = (PG && PG.DIFFICULTY_CONFIG && PG.DIFFICULTY_CONFIG[difficulty] && PG.DIFFICULTY_CONFIG[difficulty].label) || difficulty;
+      var titleStr = puzzle.dateStr + ' · ' + difficultyLabel + (M.isHardcore(mode) ? ' · 🔥 硬核' : '');
+      R.text(ctx, titleStr, rowX, rowY + 8, 13, '#666', 'left');
     } else {
       L.pauseSheet = null;
+    }
+
+    if (abandonConfirmOpen) {
+      R.overlay(ctx, W, H);
+      var dW = W * 0.84, dH = 200;
+      var dx = (W - dW) / 2, dy = (H - dH) / 2;
+      R.roundRect(ctx, dx, dy, dW, dH, 14, '#fff');
+      R.textBold(ctx, '放弃硬核?', dx + dW / 2, dy + 32, 18, '#333', 'center', 'middle');
+      R.text(ctx, '放弃后本局不再计入今日硬核通关，确定?', dx + dW / 2, dy + 70, 13, '#666', 'center');
+      var cBtnW = (dW - 48) / 2, cBtnH = 44;
+      L.abandonCancelBtn  = { x: dx + 16,                  y: dy + dH - 16 - cBtnH, w: cBtnW, h: cBtnH };
+      L.abandonConfirmBtn = { x: dx + 16 + cBtnW + 16,     y: dy + dH - 16 - cBtnH, w: cBtnW, h: cBtnH };
+      R.button(ctx, L.abandonCancelBtn.x,  L.abandonCancelBtn.y,  cBtnW, cBtnH, '取消',     '#eee',    '#333', 8);
+      R.button(ctx, L.abandonConfirmBtn.x, L.abandonConfirmBtn.y, cBtnW, cBtnH, '确定放弃', '#E64A19', '#fff', 8);
+    } else {
+      L.abandonCancelBtn = null;
+      L.abandonConfirmBtn = null;
     }
   };
 
@@ -2002,6 +2039,7 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
     if (hintMode) return;
     if (mediumMismatchModal) return;
     if (pauseMenuOpen) return;
+    if (abandonConfirmOpen) return;
 
     // Grab a placed (non-locked) block from the board, if the touch lands on
     // one. The block is lifted into `dragging` and removed from dropped; on
@@ -2083,6 +2121,7 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
 
   scene.onTouchMove = function (x, y) {
     if (pauseMenuOpen) return;
+    if (abandonConfirmOpen) return;
     if (selectPanelOpen && L.selectPanel) {
       if (!dragging) {
         var scrollDelta = dragStart.y - y;
@@ -2126,12 +2165,40 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
 
   scene.onTouchEnd = function (x, y) {
     // Pause-menu interactions take precedence when open (modal sheet).
-    if (pauseMenuOpen) {
-      // Tap inside the sheet rect: keep open (entries handled in Task 7).
-      if (L.pauseSheet && R.hitTest(x, y, L.pauseSheet)) {
+    if (abandonConfirmOpen) {
+      if (L.abandonCancelBtn && R.hitTest(x, y, L.abandonCancelBtn)) {
+        abandonConfirmOpen = false;
+        scene.dirty = true;
         return;
       }
-      // Tap outside (the dimmed overlay) closes the sheet.
+      if (L.abandonConfirmBtn && R.hitTest(x, y, L.abandonConfirmBtn)) {
+        // Downgrade: rebuild mode without hardcore, repaint, persist.
+        mode = M.createMode({ hardcore: false });
+        scene.mode = mode;
+        abandonConfirmOpen = false;
+        pauseMenuOpen = false;
+        _tempSlot.markDirty(captureState());
+        showToast('已切回普通模式');
+        scene.dirty = true;
+        return;
+      }
+      return; // swallow taps elsewhere while confirm is open
+    }
+    if (pauseMenuOpen) {
+      if (L.pauseRowAbandon && R.hitTest(x, y, L.pauseRowAbandon)) {
+        abandonConfirmOpen = true;
+        scene.dirty = true;
+        return;
+      }
+      if (L.pauseRowBack && R.hitTest(x, y, L.pauseRowBack)) {
+        pauseMenuOpen = false;
+        // Same callback path as the top-left back arrow uses.
+        if (callbacks && callbacks.onBack) callbacks.onBack();
+        return;
+      }
+      if (L.pauseSheet && R.hitTest(x, y, L.pauseSheet)) {
+        return; // tap on blank sheet area = no-op
+      }
       pauseMenuOpen = false;
       scene.dirty = true;
       return;

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -2001,6 +2001,7 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
     if (helpOpen) return;
     if (hintMode) return;
     if (mediumMismatchModal) return;
+    if (pauseMenuOpen) return;
 
     // Grab a placed (non-locked) block from the board, if the touch lands on
     // one. The block is lifted into `dragging` and removed from dropped; on
@@ -2081,6 +2082,7 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
   };
 
   scene.onTouchMove = function (x, y) {
+    if (pauseMenuOpen) return;
     if (selectPanelOpen && L.selectPanel) {
       if (!dragging) {
         var scrollDelta = dragStart.y - y;

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -121,6 +121,9 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
   // Shape: { tier: 'weak'|'medium'|'strong', cost: number, skipChecked: bool }
   var staminaConfirm = null;
 
+  // ---- Pause-menu state ----
+  var pauseMenuOpen = false;
+
   // ---- Save-slot modal state ----
   var slotModal = null;               // null | 'save-picker' | 'overwrite-warning'
   var slotPickerSelectedIdx = 0;      // 0..2
@@ -947,6 +950,15 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
       ctx.lineTo(bcx + 5, bcy + 7);
       ctx.stroke();
     }
+
+    // ☰ Pause-menu entry (top-right). Positioned mirror of backBtn relative to safe area.
+    var pmSize = 36;
+    L.pauseBtn = { x: W - pad - pmSize, y: L.backBtn.y, w: pmSize, h: pmSize };
+    ctx.fillStyle = 'rgba(0,0,0,0.06)';
+    ctx.beginPath();
+    ctx.arc(L.pauseBtn.x + pmSize / 2, L.pauseBtn.y + pmSize / 2, pmSize / 2, 0, Math.PI * 2);
+    ctx.fill();
+    R.textBold(ctx, '☰', L.pauseBtn.x + pmSize / 2, L.pauseBtn.y + pmSize / 2 - 1, 22, '#555', 'center', 'middle');
 
     // Tutorial mode hides difficulty / sub / timer / stamina so the focus
     // is purely on the puzzle and the guidance bubble.
@@ -1956,6 +1968,19 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
       var _on = slotUI.pickOldestNewest(_slots2);
       slotUI.drawOverwriteWarning(ctx, slotPickerLayoutCache, _slots2, _on.oldestIdx, _on.newestIdx, slotPickerSelectedIdx);
     }
+
+    // --- Pause-menu sheet ---
+    if (pauseMenuOpen) {
+      R.overlay(ctx, W, H);
+      var sheetH = Math.floor(H * 0.5);
+      var sheetY = H - sheetH;
+      R.roundRect(ctx, 0, sheetY, W, sheetH, 18, '#fff');
+      R.textBold(ctx, '菜单', W / 2, sheetY + 28, 18, '#333', 'center', 'middle');
+      L.pauseSheet = { x: 0, y: sheetY, w: W, h: sheetH };
+      // Entries rendered in Task 7. This block leaves a blank pane for now.
+    } else {
+      L.pauseSheet = null;
+    }
   };
 
   // ---- TOUCH ----
@@ -2098,6 +2123,23 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
   };
 
   scene.onTouchEnd = function (x, y) {
+    // Pause-menu interactions take precedence when open (modal sheet).
+    if (pauseMenuOpen) {
+      // Tap inside the sheet rect: keep open (entries handled in Task 7).
+      if (L.pauseSheet && R.hitTest(x, y, L.pauseSheet)) {
+        return;
+      }
+      // Tap outside (the dimmed overlay) closes the sheet.
+      pauseMenuOpen = false;
+      scene.dirty = true;
+      return;
+    }
+    if (L.pauseBtn && R.hitTest(x, y, L.pauseBtn)) {
+      pauseMenuOpen = true;
+      scene.dirty = true;
+      return;
+    }
+
     // ── Medium-hint mismatch modal: intercept ALL taps while open. ──
     if (mediumMismatchModal && mediumMismatchLayoutCache) {
       var mmL = mediumMismatchLayoutCache;

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -8,6 +8,7 @@ var stamina = require('./stamina');
 var shareState = require('./shareState');
 var progress = require('./progress');
 var Hint = require('./hint');
+var M = require('./mode');
 var Voucher = require('./voucher');
 var cloudClient = require('./cloudClient');
 var slotsGlobal = require('./slotsGlobal');
@@ -43,7 +44,7 @@ function setStaminaConfirmSkipUntilNext5AM() {
   } catch (e) { /* ignore */ }
 }
 
-module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRect, callbacks, savedState) {
+module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRect, callbacks, savedState, modeOpts) {
   var scene = {};
   scene.dirty = true;
 
@@ -87,6 +88,12 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
     }
   }
   var paletteOrder = palette.map(function (b) { return b.id; }); // stable display order
+
+  // Mode resolution: a restored save carries its own mode (preserves hardcore
+  // across exit/resume); a fresh game receives modeOpts from selectScene; the
+  // implicit default is non-hardcore.
+  var mode = M.createMode(savedState && savedState.mode ? savedState.mode : modeOpts);
+  scene.mode = mode;
 
   // ---- Tutorial state machine ----
   // step 1: explain the goal — bubble at today's weekday marker, advance via "下一步"
@@ -158,6 +165,7 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
       elapsedMs: timer * 1000,
       hintState: hintState,
       playedCombos: Object.assign({}, playedCombos),
+      mode: mode,
     };
   }
 

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -1981,16 +1981,25 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
       slotUI.drawOverwriteWarning(ctx, slotPickerLayoutCache, _slots2, _on.oldestIdx, _on.newestIdx, slotPickerSelectedIdx);
     }
 
-    // --- Pause-menu sheet ---
+    // --- Pause-menu popover (anchored above the ☰ button at bottom-left) ---
     if (pauseMenuOpen) {
-      R.overlay(ctx, W, H);
-      var sheetH = Math.floor(H * 0.5);
-      var sheetY = H - sheetH;
-      R.roundRect(ctx, 0, sheetY, W, sheetH, 18, '#fff');
-      R.textBold(ctx, '菜单', W / 2, sheetY + 28, 18, '#333', 'center', 'middle');
-      L.pauseSheet = { x: 0, y: sheetY, w: W, h: sheetH };
       var rowH = 56, rowGap = 8;
-      var rowX = 16, rowY = sheetY + 60, rowW = W - 32;
+      var rowsCount = (M.isHardcore(mode) ? 1 : 0) + 1;
+      var popPadX = 12, popPadTop = 12, popPadBottom = 12;
+      var titleH = 20;
+      var popW = Math.min(W - 2 * pad, 280);
+      var rowsH = rowsCount * rowH + (rowsCount - 1) * rowGap;
+      var popH = popPadTop + rowsH + 10 + titleH + popPadBottom;
+      var popX = pad;
+      var popY = L.pauseBtn.y - 8 - popH;
+      // Floating card — no full-screen dim so the popover feels light.
+      // Subtle shadow via a slightly larger gray rect underneath.
+      R.roundRect(ctx, popX + 1, popY + 2, popW, popH, 14, 'rgba(0,0,0,0.08)');
+      R.roundRect(ctx, popX, popY, popW, popH, 14, '#fff');
+      L.pauseSheet = { x: popX, y: popY, w: popW, h: popH };
+
+      var rowX = popX + popPadX, rowW = popW - 2 * popPadX;
+      var rowY = popY + popPadTop;
 
       L.pauseRowAbandon = null;
       if (M.isHardcore(mode)) {
@@ -2003,18 +2012,18 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
       R.roundRect(ctx, rowX, rowY, rowW, rowH, 12, '#F5F5F5');
       R.textBold(ctx, '🏠 返回首页', rowX + 16, rowY + rowH / 2, 16, '#333', 'left', 'middle');
       L.pauseRowBack = { x: rowX, y: rowY, w: rowW, h: rowH };
-      rowY += rowH + rowGap;
+      rowY += rowH + 10;
 
       // Read-only title block
       var difficultyLabel = (PG && PG.DIFFICULTY_CONFIG && PG.DIFFICULTY_CONFIG[difficulty] && PG.DIFFICULTY_CONFIG[difficulty].label) || difficulty;
       var titleStr = puzzle.dateStr + ' · ' + difficultyLabel + (M.isHardcore(mode) ? ' · 🔥 硬核' : '');
-      R.text(ctx, titleStr, rowX, rowY + 8, 13, '#666', 'left');
+      R.text(ctx, titleStr, rowX, rowY + 4, 13, '#666', 'left');
     } else {
       L.pauseSheet = null;
     }
 
     if (abandonConfirmOpen) {
-      if (!pauseMenuOpen) R.overlay(ctx, W, H);
+      R.overlay(ctx, W, H);
       var dW = W * 0.84, dH = 200;
       var dx = (W - dW) / 2, dy = (H - dH) / 2;
       R.roundRect(ctx, dx, dy, dW, dH, 14, '#fff');

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -1284,6 +1284,81 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
       L.staminaConfirmYesBtn = null;
     }
 
+    // --- 中提示不一致弹窗 ---
+    if (mediumMismatchModal) {
+      R.overlay(ctx, W, H);
+      var mmW = Math.min(W * 0.78, 300), mmH = 200;
+      var mmX = (W - mmW) / 2, mmY = (H - mmH) / 2;
+      R.roundRect(ctx, mmX, mmY, mmW, mmH, 14, '#fff');
+
+      // Close (×) button — top right
+      var mmCloseR = 14;
+      var mmCloseX = mmX + mmW - mmCloseR - 12;
+      var mmCloseY = mmY + mmCloseR + 12;
+      R.roundRect(ctx, mmCloseX - mmCloseR, mmCloseY - mmCloseR, mmCloseR * 2, mmCloseR * 2, mmCloseR, '#f0f0f0');
+      R.textBold(ctx, '×', mmCloseX, mmCloseY, 16, '#666', 'center', 'middle');
+
+      R.textBold(ctx, '和中提示不一致', mmX + 20, mmY + 24, 15, '#333', 'left');
+
+      // Body — figure out which block(s) to draw + the prose around them.
+      // We need block shape + color from palette OR dropped (because the
+      // placed block has just been pushed into dropped).
+      var mmAllBlocks = palette.concat(dropped);
+      function _mmFindBlock(id) {
+        for (var i = 0; i < mmAllBlocks.length; i++) if (mmAllBlocks[i].id === id) return mmAllBlocks[i];
+        return null;
+      }
+      var mmKind = mediumMismatchModal.kind;
+      var mmPlacedId = mmKind === 'right-block-wrong-loc' ? mediumMismatchModal.blockId : mediumMismatchModal.placedBlockId;
+      var mmPlacedBlk = _mmFindBlock(mmPlacedId);
+      var mmHintedBlk = mmKind === 'wrong-block-on-hint' ? _mmFindBlock(mediumMismatchModal.hintedBlockId) : null;
+
+      // Draw a mini block-shape icon at (x, y), returning the width drawn.
+      function _mmDrawIcon(blk, x, y) {
+        if (!blk) return 0;
+        var cell = 7;
+        R.blockShape(ctx, blk.shape, blk.color, x, y, cell);
+        return blk.shape[0].length * cell;
+      }
+
+      var bodyY = mmY + 64;
+      var lineH = 22;
+      if (mmKind === 'right-block-wrong-loc') {
+        R.text(ctx, '你刚把', mmX + 20, bodyY, 13, '#555', 'left', 'middle');
+        var afterPrefix = mmX + 20 + 38;
+        var iconW = _mmDrawIcon(mmPlacedBlk, afterPrefix, bodyY - 10);
+        R.text(ctx, '放到了别的位置，', afterPrefix + iconW + 6, bodyY, 13, '#555', 'left', 'middle');
+        R.text(ctx, '但它的中提示还在等它。', mmX + 20, bodyY + lineH, 13, '#555', 'left', 'middle');
+      } else {
+        R.text(ctx, '你刚把', mmX + 20, bodyY, 13, '#555', 'left', 'middle');
+        var aP = mmX + 20 + 38;
+        var iw1 = _mmDrawIcon(mmPlacedBlk, aP, bodyY - 10);
+        R.text(ctx, '放到了', aP + iw1 + 6, bodyY, 13, '#555', 'left', 'middle');
+        var aP2 = aP + iw1 + 6 + 34;
+        var iw2 = _mmDrawIcon(mmHintedBlk, aP2, bodyY - 10);
+        R.text(ctx, '的中提示位置上。', aP2 + iw2 + 6, bodyY, 13, '#555', 'left', 'middle');
+      }
+
+      // Buttons
+      var mmBtnW = mmW - 40;
+      var mmTakeBackBtnH = 36;
+      var mmTakeBackY = mmY + mmH - mmTakeBackBtnH - 36;
+      R.button(ctx, mmX + 20, mmTakeBackY, mmBtnW, mmTakeBackBtnH, '取回并重新选中', '#43A047', '#fff', 8);
+
+      var mmIgnoreH = 20;
+      var mmIgnoreY = mmY + mmH - mmIgnoreH - 10;
+      R.text(ctx, '本局不再提示', mmX + mmW / 2, mmIgnoreY + mmIgnoreH / 2, 12, '#999', 'center', 'middle');
+
+      mediumMismatchLayoutCache = {
+        modal: { x: mmX, y: mmY, w: mmW, h: mmH },
+        closeBtn: { x: mmCloseX - mmCloseR, y: mmCloseY - mmCloseR, w: mmCloseR * 2, h: mmCloseR * 2 },
+        takeBackBtn: { x: mmX + 20, y: mmTakeBackY, w: mmBtnW, h: mmTakeBackBtnH },
+        ignoreBtn: { x: mmX + 20, y: mmIgnoreY, w: mmBtnW, h: mmIgnoreH + 4 },
+      };
+    } else {
+      mediumMismatchLayoutCache = null;
+    }
+
     // --- 获取路径 二级 menu ---
     if (sourceMenuOpen && L.sourceMenu) {
       R.overlay(ctx, W, H);

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -2445,7 +2445,6 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
               showToast('已提示 ' + hBlock.label + ' 的正确方向');
             } else if (hintTier === 'medium') {
               res = Hint.applyMedium(hintState, hBlock.id, palette, dropped, solvedPlacements);
-              showToast('已提示 ' + hBlock.label + ' 的落点');
             } else {
               res = Hint.applyStrong(hintState, hBlock.id, palette, dropped, solvedPlacements);
               showToast('已为 ' + hBlock.label + ' 落子');

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -2003,7 +2003,7 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
     }
 
     if (abandonConfirmOpen) {
-      R.overlay(ctx, W, H);
+      if (!pauseMenuOpen) R.overlay(ctx, W, H);
       var dW = W * 0.84, dH = 200;
       var dx = (W - dW) / 2, dy = (H - dH) / 2;
       R.roundRect(ctx, dx, dy, dW, dH, 14, '#fff');

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -434,12 +434,18 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
         if (isInsomnia) {
           insomniaUnique = progress.markUniqueInsomnia(puzzle.dateStr, buildBoardKey());
         }
+        var hardcoreClear = false;
+        if (M.isHardcore(mode)) {
+          progress.markHardcoreCleared(puzzle.dateStr, difficulty);
+          hardcoreClear = true;
+        }
         winStats = {
           time: timer,
           isNewPB: pb.isNew,
           prevPB: pb.prev,
           todayDone: progress.countCompletedForDate(puzzle.dateStr),
           insomniaUnique: insomniaUnique,
+          hardcore: hardcoreClear,
         };
         var _bound = _slotBinding.getBound();
         if (_bound) {
@@ -1804,6 +1810,9 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
       R.textBold(ctx, '×', L.winCloseBtn.x + clz / 2, L.winCloseBtn.y + clz / 2 - 1, 20, '#666', 'center', 'middle');
 
       R.textBold(ctx, '🎉 通关！', cardX + cardW / 2, cardY + 22, 20, BRAND_DARK, 'center');
+      if (winStats.hardcore) {
+        R.textBold(ctx, '🔥 硬核通关', cardX + cardW / 2, cardY + 44, 16, '#E64A19', 'center', 'middle');
+      }
       R.textBold(ctx, B.formatTime(winStats.time),
         cardX + cardW / 2, cardY + 60, 26, '#333', 'center', 'middle');
       var sub;

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -958,9 +958,10 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
       ctx.stroke();
     }
 
-    // ☰ Pause-menu entry (top-right). Positioned mirror of backBtn relative to safe area.
+    // ☰ Pause-menu entry (bottom-left). Avoids collision with the WeChat
+    // capsule menu at top-right and the centered palette/hint at bottom.
     var pmSize = 36;
-    L.pauseBtn = { x: W - pad - pmSize, y: L.backBtn.y, w: pmSize, h: pmSize };
+    L.pauseBtn = { x: pad, y: H - padBottom - pmSize - 4, w: pmSize, h: pmSize };
     ctx.fillStyle = 'rgba(0,0,0,0.06)';
     ctx.beginPath();
     ctx.arc(L.pauseBtn.x + pmSize / 2, L.pauseBtn.y + pmSize / 2, pmSize / 2, 0, Math.PI * 2);

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -2073,6 +2073,43 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
   };
 
   scene.onTouchEnd = function (x, y) {
+    // ── Medium-hint mismatch modal: intercept ALL taps while open. ──
+    if (mediumMismatchModal && mediumMismatchLayoutCache) {
+      var mmL = mediumMismatchLayoutCache;
+      // Take back: remove the offending placed block + re-select it in palette.
+      if (R.hitTest(x, y, mmL.takeBackBtn)) {
+        var mmPlacedId = mediumMismatchModal.kind === 'right-block-wrong-loc'
+          ? mediumMismatchModal.blockId
+          : mediumMismatchModal.placedBlockId;
+        removeDropped(mmPlacedId);
+        for (var pi = palette.length - 1; pi >= 0; pi--) {
+          if (palette[pi].id === mmPlacedId) { selected = palette[pi]; break; }
+        }
+        mediumMismatchModal = null;
+        mediumMismatchLayoutCache = null;
+        scene.dirty = true;
+        return;
+      }
+      // Ignore for the rest of this puzzle (persists across reload via hintState).
+      if (R.hitTest(x, y, mmL.ignoreBtn)) {
+        hintState = Hint.setMediumMismatchIgnored(hintState);
+        _tempSlot.markDirty(captureState());
+        mediumMismatchModal = null;
+        mediumMismatchLayoutCache = null;
+        scene.dirty = true;
+        return;
+      }
+      // Close — dismiss this instance only; next mismatch re-opens dialog.
+      if (R.hitTest(x, y, mmL.closeBtn)) {
+        mediumMismatchModal = null;
+        mediumMismatchLayoutCache = null;
+        scene.dirty = true;
+        return;
+      }
+      // Tap on dialog backdrop / anywhere else — swallow, no fall-through.
+      return;
+    }
+
     // ── Save-slot modals: intercept ALL taps while a modal is open. ──
     if (slotModal === 'save-picker' && slotPickerLayoutCache) {
       var hit = slotUI.savePickerHitTest(x, y, slotPickerLayoutCache);

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -118,6 +118,13 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
   var slotModal = null;               // null | 'save-picker' | 'overwrite-warning'
   var slotPickerSelectedIdx = 0;      // 0..2
   var slotPickerLayoutCache = null;   // cached layout for the active modal
+
+  // ---- Medium-hint mismatch modal state ----
+  // null when no dialog open. Set by placeBlock() to one of:
+  //   { kind: 'right-block-wrong-loc', blockId }
+  //   { kind: 'wrong-block-on-hint', placedBlockId, hintedBlockId }
+  var mediumMismatchModal = null;
+  var mediumMismatchLayoutCache = null;
   function currentPuzzleId() {
     return puzzle.dateStr + ':' + difficulty + ':c' + puzzle.currentComboIndex;
   }
@@ -461,6 +468,19 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
     try { wx.vibrateShort && wx.vibrateShort({ type: 'medium' }); } catch (e) {}
     scene.dirty = true;
     _tempSlot.markDirty(captureState());
+    if (!hintState.mediumMismatchIgnored) {
+      var bCells = [];
+      for (var sy = 0; sy < nb.shape.length; sy++) {
+        for (var sx = 0; sx < nb.shape[sy].length; sx++) {
+          if (nb.shape[sy][sx] === 1) bCells.push({ x: nb.x + sx, y: nb.y + sy });
+        }
+      }
+      var mm = Hint.findMediumMismatch(hintState, nb.id, bCells);
+      if (mm) {
+        mediumMismatchModal = mm;
+        return;
+      }
+    }
     checkWin();
   }
 

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -1323,20 +1323,28 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
 
       var bodyY = mmY + 64;
       var lineH = 22;
+      // Measure text width via ctx.measureText so inline icon positions don't
+      // depend on eyeballed CJK glyph widths (varies across WeChat WebView fonts).
+      function _mmMeasure(str) {
+        ctx.font = '13px sans-serif';
+        return ctx.measureText(str).width;
+      }
+      var gap = 4;
       if (mmKind === 'right-block-wrong-loc') {
         R.text(ctx, '你刚把', mmX + 20, bodyY, 13, '#555', 'left', 'middle');
-        var afterPrefix = mmX + 20 + 38;
+        var afterPrefix = mmX + 20 + _mmMeasure('你刚把') + gap;
         var iconW = _mmDrawIcon(mmPlacedBlk, afterPrefix, bodyY - 10);
-        R.text(ctx, '放到了别的位置，', afterPrefix + iconW + 6, bodyY, 13, '#555', 'left', 'middle');
+        R.text(ctx, '放到了别的位置，', afterPrefix + iconW + gap, bodyY, 13, '#555', 'left', 'middle');
         R.text(ctx, '但它的中提示还在等它。', mmX + 20, bodyY + lineH, 13, '#555', 'left', 'middle');
       } else {
         R.text(ctx, '你刚把', mmX + 20, bodyY, 13, '#555', 'left', 'middle');
-        var aP = mmX + 20 + 38;
+        var aP = mmX + 20 + _mmMeasure('你刚把') + gap;
         var iw1 = _mmDrawIcon(mmPlacedBlk, aP, bodyY - 10);
-        R.text(ctx, '放到了', aP + iw1 + 6, bodyY, 13, '#555', 'left', 'middle');
-        var aP2 = aP + iw1 + 6 + 34;
+        var afterPlaced = aP + iw1 + gap;
+        R.text(ctx, '放到了', afterPlaced, bodyY, 13, '#555', 'left', 'middle');
+        var aP2 = afterPlaced + _mmMeasure('放到了') + gap;
         var iw2 = _mmDrawIcon(mmHintedBlk, aP2, bodyY - 10);
-        R.text(ctx, '的中提示位置上。', aP2 + iw2 + 6, bodyY, 13, '#555', 'left', 'middle');
+        R.text(ctx, '的中提示位置上。', aP2 + iw2 + gap, bodyY, 13, '#555', 'left', 'middle');
       }
 
       // Buttons

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -1304,31 +1304,31 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
       // We need block shape + color from palette OR dropped (because the
       // placed block has just been pushed into dropped).
       var mmAllBlocks = palette.concat(dropped);
-      function _mmFindBlock(id) {
+      var _mmFindBlock = function (id) {
         for (var i = 0; i < mmAllBlocks.length; i++) if (mmAllBlocks[i].id === id) return mmAllBlocks[i];
         return null;
-      }
+      };
       var mmKind = mediumMismatchModal.kind;
       var mmPlacedId = mmKind === 'right-block-wrong-loc' ? mediumMismatchModal.blockId : mediumMismatchModal.placedBlockId;
       var mmPlacedBlk = _mmFindBlock(mmPlacedId);
       var mmHintedBlk = mmKind === 'wrong-block-on-hint' ? _mmFindBlock(mediumMismatchModal.hintedBlockId) : null;
 
       // Draw a mini block-shape icon at (x, y), returning the width drawn.
-      function _mmDrawIcon(blk, x, y) {
+      var _mmDrawIcon = function (blk, x, y) {
         if (!blk) return 0;
         var cell = 7;
         R.blockShape(ctx, blk.shape, blk.color, x, y, cell);
         return blk.shape[0].length * cell;
-      }
+      };
 
       var bodyY = mmY + 64;
       var lineH = 22;
       // Measure text width via ctx.measureText so inline icon positions don't
       // depend on eyeballed CJK glyph widths (varies across WeChat WebView fonts).
-      function _mmMeasure(str) {
+      var _mmMeasure = function (str) {
         ctx.font = '13px sans-serif';
         return ctx.measureText(str).width;
-      }
+      };
       var gap = 4;
       if (mmKind === 'right-block-wrong-loc') {
         R.text(ctx, '你刚把', mmX + 20, bodyY, 13, '#555', 'left', 'middle');
@@ -1951,6 +1951,7 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
     }
     if (helpOpen) return;
     if (hintMode) return;
+    if (mediumMismatchModal) return;
 
     // Grab a placed (non-locked) block from the board, if the touch lands on
     // one. The block is lifted into `dragging` and removed from dropped; on

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -960,8 +960,10 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
 
     // ☰ Pause-menu entry (bottom-left). Avoids collision with the WeChat
     // capsule menu at top-right and the centered palette/hint at bottom.
+    // safeInsets.bottom is the home-indicator inset; padBottom is local to
+    // computeLayout, not in scope here.
     var pmSize = 36;
-    L.pauseBtn = { x: pad, y: H - padBottom - pmSize - 4, w: pmSize, h: pmSize };
+    L.pauseBtn = { x: pad, y: H - (safeInsets.bottom || 0) - pmSize - 4, w: pmSize, h: pmSize };
     ctx.fillStyle = 'rgba(0,0,0,0.06)';
     ctx.beginPath();
     ctx.arc(L.pauseBtn.x + pmSize / 2, L.pauseBtn.y + pmSize / 2, pmSize / 2, 0, Math.PI * 2);

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -653,23 +653,36 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
     // it needs to point at. Skip button is placed inside the bubble (laid
     // out at render time, not here).
 
-    // Control row: 提示 / 重开 / 🎲 / 🎯  — single line, 4 icons (2 in insomnia
-    // mode, where switching puzzle is conceptually nonexistent).
+    // Control row: 提示 / 重开 / 🎲 / 🎯  — single line.
+    // Layout collapses based on capabilities:
+    //   default:  [💡 提示] [↺ 重开] [🎲 随机] [🎯 选题]      (4 buttons)
+    //   insomnia: [💡 提示] [↺ 重开]                          (2 buttons; no swap)
+    //   hardcore: [🧹 清空]                                    (1 button; replaces 重开)
     // Hidden during tutorial mode to keep the focus on the banner step.
     L.hintBtn = null;
     L.resetBtn = null;
     L.switchRandomBtn = null;
     L.switchManualBtn = null;
     if (!tutorialMode) {
+      var showHint = M.canUseHint(mode);
+      var showSwap = M.canSwapPuzzle(mode) && !isInsomnia;
+      var hardcore = M.isHardcore(mode);
+      var nCtrl = (showHint ? 1 : 0) + 1 /* reset/clear */ + (showSwap ? 2 : 0);
       var btnH = 36, btnGap = 8;
-      var nCtrl = isInsomnia ? 2 : 4;
       var ctrlBtnW = Math.floor((W - 2 * pad - (nCtrl - 1) * btnGap) / nCtrl);
       L.ctrlY = y;
-      L.hintBtn  = { x: pad,                                   y: y, w: ctrlBtnW, h: btnH };
-      L.resetBtn = { x: pad + (ctrlBtnW + btnGap) * 1,         y: y, w: ctrlBtnW, h: btnH };
-      if (!isInsomnia) {
-        L.switchRandomBtn = { x: pad + (ctrlBtnW + btnGap) * 2,  y: y, w: ctrlBtnW, h: btnH };
-        L.switchManualBtn = { x: pad + (ctrlBtnW + btnGap) * 3,  y: y, w: ctrlBtnW, h: btnH };
+      var idx = 0;
+      if (showHint) {
+        L.hintBtn  = { x: pad + (ctrlBtnW + btnGap) * idx, y: y, w: ctrlBtnW, h: btnH };
+        idx++;
+      }
+      L.resetBtn   = { x: pad + (ctrlBtnW + btnGap) * idx, y: y, w: ctrlBtnW, h: btnH, kind: hardcore ? 'clear' : 'reset' };
+      idx++;
+      if (showSwap) {
+        L.switchRandomBtn = { x: pad + (ctrlBtnW + btnGap) * idx, y: y, w: ctrlBtnW, h: btnH };
+        idx++;
+        L.switchManualBtn = { x: pad + (ctrlBtnW + btnGap) * idx, y: y, w: ctrlBtnW, h: btnH };
+        idx++;
       }
       y += btnH + 10;
     }
@@ -961,9 +974,12 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
     //  can compute targets from their freshly-laid-out rects.)
 
     // --- Control row: 提示 / 重开 / 🎲 / 🎯 (hidden during tutorial) ---
-    if (L.hintBtn) {
-      R.button(ctx, L.hintBtn.x, L.hintBtn.y, L.hintBtn.w, L.hintBtn.h, '💡 提示', BRAND, '#fff', 8);
-      R.button(ctx, L.resetBtn.x, L.resetBtn.y, L.resetBtn.w, L.resetBtn.h, '↺ 重开', dropped.length ? NEUTRAL : '#cfcfcf', '#fff', 8);
+    if (L.resetBtn) {
+      if (L.hintBtn) {
+        R.button(ctx, L.hintBtn.x, L.hintBtn.y, L.hintBtn.w, L.hintBtn.h, '💡 提示', BRAND, '#fff', 8);
+      }
+      var resetLabel = L.resetBtn.kind === 'clear' ? '🧹 清空' : '↺ 重开';
+      R.button(ctx, L.resetBtn.x, L.resetBtn.y, L.resetBtn.w, L.resetBtn.h, resetLabel, dropped.length ? NEUTRAL : '#cfcfcf', '#fff', 8);
       if (L.switchRandomBtn) {
         var randomBg = switchMode === 'random' ? BRAND : '#E0E0E0';
         var randomFg = switchMode === 'random' ? '#fff' : '#666';
@@ -2640,8 +2656,15 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
     }
     if (L.resetBtn && R.hitTest(x, y, L.resetBtn)) {
       if (dropped.length === 0) return;
-      resetAllPlaced();
-      showToast('已重开当前题');
+      if (L.resetBtn.kind === 'clear') {
+        // Hardcore: clear all dropped blocks back to palette; DO NOT reset timer.
+        resetAllPlaced();
+        showToast('已清空棋盘');
+      } else {
+        // Default restart: delegates to resetAllPlaced (no timer state here).
+        resetAllPlaced();
+        showToast('已重开当前题');
+      }
       return;
     }
     if (L.switchRandomBtn && R.hitTest(x, y, L.switchRandomBtn)) {

--- a/calendar-puzzle-miniprogram/minigame/js/gameScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/gameScene.js
@@ -1786,7 +1786,8 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
       var cardW = Math.min(W - 32, 320);
       // Tutorial stacks 2 (finish + invite). Regular win stacks 3
       // (restart / moments-hint / invite), so grow the card to match.
-      var cardH = tutorialMode ? 250 : 310;
+      var hcShift = (winStats && winStats.hardcore) ? 24 : 0;
+      var cardH = (tutorialMode ? 250 : 310) + hcShift;
       var cardX = (W - cardW) / 2;
       var cardY = Math.max(L.boardY + L.boardH / 2 - cardH / 2, L.headerY + 80);
       // Clamp against the bottom safe area so the taller 3-button card
@@ -1811,10 +1812,10 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
 
       R.textBold(ctx, '🎉 通关！', cardX + cardW / 2, cardY + 22, 20, BRAND_DARK, 'center');
       if (winStats.hardcore) {
-        R.textBold(ctx, '🔥 硬核通关', cardX + cardW / 2, cardY + 44, 16, '#E64A19', 'center', 'middle');
+        R.textBold(ctx, '🔥 硬核通关', cardX + cardW / 2, cardY + 50, 16, '#E64A19', 'center', 'middle');
       }
       R.textBold(ctx, B.formatTime(winStats.time),
-        cardX + cardW / 2, cardY + 60, 26, '#333', 'center', 'middle');
+        cardX + cardW / 2, cardY + 60 + hcShift, 26, '#333', 'center', 'middle');
       var sub;
       if (winStats.isNewPB && winStats.prevPB != null) {
         sub = '🏆 新纪录！（前最佳 ' + B.formatTime(winStats.prevPB) + '）';
@@ -1823,18 +1824,18 @@ module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRe
       } else {
         sub = '最佳 ' + B.formatTime(progress.getBestTime(puzzle.dateStr, difficulty));
       }
-      R.text(ctx, sub, cardX + cardW / 2, cardY + 88, 12,
+      R.text(ctx, sub, cardX + cardW / 2, cardY + 88 + hcShift, 12,
         winStats.isNewPB ? '#FF8F00' : '#888', 'center');
       if (isInsomnia && winStats.insomniaUnique) {
         var iu = winStats.insomniaUnique;
         var iuTxt = iu.isNew
           ? '✨ 新摆法 · 今日已发现 ' + iu.count + ' 种'
           : '🌙 这种摆法见过了 · 今日 ' + iu.count + ' 种';
-        R.text(ctx, iuTxt, cardX + cardW / 2, cardY + 110, 12,
+        R.text(ctx, iuTxt, cardX + cardW / 2, cardY + 110 + hcShift, 12,
           iu.isNew ? '#FF8F00' : '#888', 'center');
       } else {
         R.text(ctx, '今日已通关 ' + winStats.todayDone + ' 题',
-          cardX + cardW / 2, cardY + 110, 12, '#666', 'center');
+          cardX + cardW / 2, cardY + 110 + hcShift, 12, '#666', 'center');
       }
 
       // Stacked CTAs. Tutorial: [finish, invite]. Normal win:

--- a/calendar-puzzle-miniprogram/minigame/js/hint.js
+++ b/calendar-puzzle-miniprogram/minigame/js/hint.js
@@ -158,6 +158,7 @@ function applyWeak(state, blockId, palette, dropped, solvedPlacements) {
     usedWeak: state.usedWeak + 1,
     usedMedium: state.usedMedium,
     usedStrong: state.usedStrong,
+    mediumMismatchIgnored: state.mediumMismatchIgnored,
   };
 
   return { newState: newState, updatedPalette: newPalette, updatedDropped: newDropped };
@@ -232,6 +233,7 @@ function applyMedium(state, blockId, palette, dropped, solvedPlacements) {
     usedWeak: state.usedWeak,
     usedMedium: state.usedMedium + 1,
     usedStrong: state.usedStrong,
+    mediumMismatchIgnored: state.mediumMismatchIgnored,
   };
 
   return { newState: newState, updatedPalette: newPalette, updatedDropped: newDropped, hintedCell: newCell };
@@ -325,6 +327,7 @@ function applyStrong(state, blockId, palette, dropped, solvedPlacements) {
     usedWeak: state.usedWeak,
     usedMedium: state.usedMedium,
     usedStrong: state.usedStrong + 1,
+    mediumMismatchIgnored: state.mediumMismatchIgnored,
   };
 
   return { newState: newState, updatedPalette: newPalette, updatedDropped: newDropped, evictedIds: evictedIds };

--- a/calendar-puzzle-miniprogram/minigame/js/hint.js
+++ b/calendar-puzzle-miniprogram/minigame/js/hint.js
@@ -379,6 +379,13 @@ function findMediumMismatch(state, blockId, blockCells) {
   return null;
 }
 
+// Immutable setter for the per-puzzle "stop bugging me about medium mismatches"
+// flag. Caller writes the returned state back into hintState; the field
+// survives save/reload via restoreHintState.
+function setMediumMismatchIgnored(state) {
+  return Object.assign({}, state, { mediumMismatchIgnored: true });
+}
+
 module.exports = {
   CAPS: CAPS,
   COSTS: COSTS,
@@ -392,6 +399,7 @@ module.exports = {
   isFullyLocked: isFullyLocked,
   isMediumExhausted: isMediumExhausted,
   findMediumMismatch: findMediumMismatch,
+  setMediumMismatchIgnored: setMediumMismatchIgnored,
   applyWeak: applyWeak,
   applyMedium: applyMedium,
   applyStrong: applyStrong,

--- a/calendar-puzzle-miniprogram/minigame/js/hint.js
+++ b/calendar-puzzle-miniprogram/minigame/js/hint.js
@@ -333,6 +333,51 @@ function applyStrong(state, blockId, palette, dropped, solvedPlacements) {
   return { newState: newState, updatedPalette: newPalette, updatedDropped: newDropped, evictedIds: evictedIds };
 }
 
+// Returns the first medium-hint violation caused by placing `blockId` at the
+// cells in `blockCells`. Priority: a block that has its own active medium
+// hint and fails to cover all of its hint cells wins over a block (own or
+// foreign) that happens to land on another block's hint cells. Pure function.
+//   state: hintState
+//   blockId: string — the block that was just dropped
+//   blockCells: Array<{x, y}> — the cells `blockId` occupies after the drop
+// Returns:
+//   null — no violation
+//   { kind: 'right-block-wrong-loc', blockId } — own hint not fully covered
+//   { kind: 'wrong-block-on-hint', placedBlockId, hintedBlockId } — covers
+//     another block's hint cell
+function findMediumMismatch(state, blockId, blockCells) {
+  if (!state || !state.mediumLocked) return null;
+  var ownHint = state.mediumLocked[blockId];
+  if (ownHint && ownHint.length > 0) {
+    // Scenario B — does blockCells contain every hinted cell?
+    var coversAll = true;
+    for (var i = 0; i < ownHint.length; i++) {
+      var hc = ownHint[i];
+      var found = false;
+      for (var j = 0; j < blockCells.length; j++) {
+        if (blockCells[j].x === hc.x && blockCells[j].y === hc.y) { found = true; break; }
+      }
+      if (!found) { coversAll = false; break; }
+    }
+    if (!coversAll) return { kind: 'right-block-wrong-loc', blockId: blockId };
+  }
+  // Scenario A — does blockCells intersect any other block's mediumLocked cells?
+  for (var hintedId in state.mediumLocked) {
+    if (!Object.prototype.hasOwnProperty.call(state.mediumLocked, hintedId)) continue;
+    if (hintedId === blockId) continue;
+    var cells = state.mediumLocked[hintedId];
+    if (!cells || cells.length === 0) continue;
+    for (var ci = 0; ci < cells.length; ci++) {
+      for (var bi = 0; bi < blockCells.length; bi++) {
+        if (blockCells[bi].x === cells[ci].x && blockCells[bi].y === cells[ci].y) {
+          return { kind: 'wrong-block-on-hint', placedBlockId: blockId, hintedBlockId: hintedId };
+        }
+      }
+    }
+  }
+  return null;
+}
+
 module.exports = {
   CAPS: CAPS,
   COSTS: COSTS,
@@ -345,6 +390,7 @@ module.exports = {
   isCellLocked: isCellLocked,
   isFullyLocked: isFullyLocked,
   isMediumExhausted: isMediumExhausted,
+  findMediumMismatch: findMediumMismatch,
   applyWeak: applyWeak,
   applyMedium: applyMedium,
   applyStrong: applyStrong,

--- a/calendar-puzzle-miniprogram/minigame/js/hint.js
+++ b/calendar-puzzle-miniprogram/minigame/js/hint.js
@@ -347,6 +347,7 @@ function applyStrong(state, blockId, palette, dropped, solvedPlacements) {
 //     another block's hint cell
 function findMediumMismatch(state, blockId, blockCells) {
   if (!state || !state.mediumLocked) return null;
+  if (!blockCells || blockCells.length === 0) return null;
   var ownHint = state.mediumLocked[blockId];
   if (ownHint && ownHint.length > 0) {
     // Scenario B — does blockCells contain every hinted cell?

--- a/calendar-puzzle-miniprogram/minigame/js/hint.js
+++ b/calendar-puzzle-miniprogram/minigame/js/hint.js
@@ -13,6 +13,7 @@ function createHintState(puzzleId) {
     usedWeak: 0,
     usedMedium: 0,
     usedStrong: 0,
+    mediumMismatchIgnored: false,
   };
 }
 
@@ -70,6 +71,7 @@ function restoreHintState(saved, puzzleId) {
     usedWeak: typeof saved.usedWeak === 'number' ? saved.usedWeak : 0,
     usedMedium: typeof saved.usedMedium === 'number' ? saved.usedMedium : 0,
     usedStrong: typeof saved.usedStrong === 'number' ? saved.usedStrong : 0,
+    mediumMismatchIgnored: saved.mediumMismatchIgnored === true,
   };
 }
 

--- a/calendar-puzzle-miniprogram/minigame/js/main.js
+++ b/calendar-puzzle-miniprogram/minigame/js/main.js
@@ -170,15 +170,15 @@ function showLoading() {
 
 function goToSelect() {
   if (currentScene && currentScene.destroy) currentScene.destroy();
-  currentScene = createSelectScene(safeInsets, menuRect, function (difficulty, savedState) {
-    startGame(difficulty, savedState);
+  currentScene = createSelectScene(safeInsets, menuRect, function (difficulty, savedState, modeOpts) {
+    startGame(difficulty, savedState, modeOpts);
   }, {
     onReplayTutorial: function () { startTutorial(); },
   });
   currentScene.dirty = true;
 }
 
-function startGame(difficulty, savedState) {
+function startGame(difficulty, savedState, modeOpts) {
   if (currentScene && currentScene.destroy) currentScene.destroy();
   currentScene = null; // clear while generating
 
@@ -193,11 +193,11 @@ function startGame(difficulty, savedState) {
       goToSelect();
       return;
     }
-    launchGameScene(difficulty, puzzle, savedState);
+    launchGameScene(difficulty, puzzle, savedState, modeOpts);
   }, 50);
 }
 
-function launchGameScene(difficulty, puzzle, savedState) {
+function launchGameScene(difficulty, puzzle, savedState, modeOpts) {
   shareState.setCurrent({
     difficulty: difficulty,
     difficultyLabel: PG.DIFFICULTY_CONFIG[difficulty].label,
@@ -207,7 +207,7 @@ function launchGameScene(difficulty, puzzle, savedState) {
   if (currentScene && currentScene.destroy) currentScene.destroy();
   currentScene = createGameScene(difficulty, puzzle, safeInsets, menuRect, {
     onSwitchPuzzle: function (newPuzzle) {
-      launchGameScene(difficulty, newPuzzle);
+      launchGameScene(difficulty, newPuzzle, null, currentScene && currentScene.mode ? currentScene.mode : null);
     },
     onBack: function () {
       // Tutorial → shared-puzzle handoff: if a friend's share-card brought a
@@ -219,7 +219,7 @@ function launchGameScene(difficulty, puzzle, savedState) {
       }
       goToSelect();
     },
-  }, savedState);
+  }, savedState, modeOpts);
   currentScene.dirty = true;
 }
 

--- a/calendar-puzzle-miniprogram/minigame/js/mode.js
+++ b/calendar-puzzle-miniprogram/minigame/js/mode.js
@@ -1,0 +1,32 @@
+// Mode object lives on gameScene and rides save-slot payloads.
+//
+// Capability helpers are the single source of truth for "what does this
+// mode allow"; gameScene render/hit-test branches consult them instead of
+// hard-coding `mode.hardcore`. Future modes (timed, daily-challenge) extend
+// this same surface.
+
+var DEFAULT_MODE = { hardcore: false };
+
+function createMode(opts) {
+  opts = opts || {};
+  return { hardcore: !!opts.hardcore };
+}
+
+function isHardcore(mode) {
+  return !!(mode && mode.hardcore);
+}
+
+function canUseHint(mode)    { return !isHardcore(mode); }
+function canSwapPuzzle(mode) { return !isHardcore(mode); }
+function canRestart(mode)    { return !isHardcore(mode); }
+function canClearBoard(mode) { return true; }
+
+module.exports = {
+  DEFAULT_MODE: DEFAULT_MODE,
+  createMode: createMode,
+  isHardcore: isHardcore,
+  canUseHint: canUseHint,
+  canSwapPuzzle: canSwapPuzzle,
+  canRestart: canRestart,
+  canClearBoard: canClearBoard,
+};

--- a/calendar-puzzle-miniprogram/minigame/js/progress.js
+++ b/calendar-puzzle-miniprogram/minigame/js/progress.js
@@ -111,6 +111,37 @@ function markUniqueInsomnia(dateStr, boardKey) {
   return { isNew: true, count: arr.length };
 }
 
+// Hardcore mode: per-day per-difficulty clear flag.
+// Storage shape: { "2026-05-27": { "expert": true, "easy": true }, ... }
+var HARDCORE_KEY = 'calendarPuzzleHardcoreDays';
+
+function loadHardcore() {
+  try { var r = wx.getStorageSync(HARDCORE_KEY); if (r) return JSON.parse(r); } catch (e) {}
+  return {};
+}
+
+function saveHardcore(d) {
+  try { wx.setStorageSync(HARDCORE_KEY, JSON.stringify(d)); } catch (e) {}
+}
+
+// Returns true on first-time-at-this-(date, difficulty); false if already set.
+function markHardcoreCleared(dateStr, difficulty) {
+  if (!dateStr || !difficulty) return false;
+  var all = loadHardcore();
+  var entry = all[dateStr] = all[dateStr] || {};
+  if (entry[difficulty]) return false;
+  entry[difficulty] = true;
+  saveHardcore(all);
+  return true;
+}
+
+function hasHardcoreCleared(dateStr, difficulty) {
+  if (!dateStr || !difficulty) return false;
+  var all = loadHardcore();
+  var entry = all[dateStr];
+  return !!(entry && entry[difficulty]);
+}
+
 // First-launch onboarding completion flag.
 var TUTORIAL_KEY = 'calendarPuzzleTutorialDone';
 
@@ -132,4 +163,6 @@ module.exports = {
   markUniqueInsomnia: markUniqueInsomnia,
   isTutorialDone: isTutorialDone,
   markTutorialDone: markTutorialDone,
+  markHardcoreCleared: markHardcoreCleared,
+  hasHardcoreCleared: hasHardcoreCleared,
 };

--- a/calendar-puzzle-miniprogram/minigame/js/selectScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/selectScene.js
@@ -137,7 +137,8 @@ module.exports = function createSelectScene(safeInsets, menuRect, onSelect, call
         expert: '#7E57C2', insomnia: '#E53935',
       };
       // Shrink button height if buttons would overflow the remaining space.
-      var availH = H - y - padBottom - 16;
+      var TOGGLE_ROW_RESERVE = 56; // hardcore toggle row (36) + gap (2) + caption (18); see render block below
+      var availH = H - y - padBottom - 16 - TOGGLE_ROW_RESERVE;
       var needH = diffs.length * btnH + (diffs.length - 1) * btnGap;
       if (needH > availH) {
         btnH = Math.max(44, Math.floor((availH - (diffs.length - 1) * btnGap) / diffs.length));
@@ -341,7 +342,7 @@ module.exports = function createSelectScene(safeInsets, menuRect, onSelect, call
             showMsg('体力不足！需要 ' + pdCost + ' 点，当前 ' + stamina.getStamina() + ' 点');
             return;
           }
-          onSelect(pd, null, null);
+          onSelect(pd, null, { hardcore: hardcoreOn });
         }
         return;
       }

--- a/calendar-puzzle-miniprogram/minigame/js/selectScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/selectScene.js
@@ -295,7 +295,7 @@ module.exports = function createSelectScene(safeInsets, menuRect, onSelect, call
         if (saved) {
           modal = null; continueLayoutCache = null;
           scene.dirty = true;
-          onSelect(saved.difficulty, saved);
+          onSelect(saved.difficulty, saved, null);
         }
         return;
       }
@@ -312,7 +312,7 @@ module.exports = function createSelectScene(safeInsets, menuRect, onSelect, call
             showMsg('体力不足！需要 ' + pdCost + ' 点，当前 ' + stamina.getStamina() + ' 点');
             return;
           }
-          onSelect(pd, null);
+          onSelect(pd, null, null);
         }
         return;
       }
@@ -339,7 +339,7 @@ module.exports = function createSelectScene(safeInsets, menuRect, onSelect, call
           mode = 'menu';
           slotGridLayoutCache = null;
           scene.dirty = true;
-          onSelect(slotPayload.difficulty, slotPayload);
+          onSelect(slotPayload.difficulty, slotPayload, null);
           return;
         }
         // empty slot — ignore tap
@@ -389,7 +389,7 @@ module.exports = function createSelectScene(safeInsets, menuRect, onSelect, call
           showMsg('体力不足！需要 ' + cost + ' 点，当前 ' + stamina.getStamina() + ' 点');
           return;
         }
-        onSelect(d, null);
+        onSelect(d, null, null);
         return;
       }
     }

--- a/calendar-puzzle-miniprogram/minigame/js/selectScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/selectScene.js
@@ -9,6 +9,17 @@ var slotUI = require('./slotUI');
 var slotStoreModule = require('./slotStore');
 var NAMED_SLOT_IDS = slotStoreModule.NAMED_SLOT_IDS || ['named-1', 'named-2', 'named-3'];
 
+// Hardcore toggle preference is persisted across launches so the player
+// keeps their choice between visits. Errors swallowed — toggle simply
+// defaults to OFF if storage is unavailable.
+var HARDCORE_ON_KEY = 'calendarPuzzleHardcoreOn';
+function loadHardcoreOn() {
+  try { return wx.getStorageSync(HARDCORE_ON_KEY) === '1'; } catch (e) { return false; }
+}
+function saveHardcoreOn(on) {
+  try { wx.setStorageSync(HARDCORE_ON_KEY, on ? '1' : ''); } catch (e) {}
+}
+
 module.exports = function createSelectScene(safeInsets, menuRect, onSelect, callbacks) {
   callbacks = callbacks || {};
   var scene = {};
@@ -27,7 +38,7 @@ module.exports = function createSelectScene(safeInsets, menuRect, onSelect, call
 
   var btnRects = [];
   var infoBtn = null;
-  var hardcoreOn = false;
+  var hardcoreOn = loadHardcoreOn();
   var hardcoreToggleRect = null;
   var helpOpen = false;
   var replayBtn = null;
@@ -403,6 +414,7 @@ module.exports = function createSelectScene(safeInsets, menuRect, onSelect, call
 
     if (hardcoreToggleRect && R.hitTest(x, y, hardcoreToggleRect)) {
       hardcoreOn = !hardcoreOn;
+      saveHardcoreOn(hardcoreOn);
       scene.dirty = true;
       return;
     }

--- a/calendar-puzzle-miniprogram/minigame/js/selectScene.js
+++ b/calendar-puzzle-miniprogram/minigame/js/selectScene.js
@@ -27,6 +27,8 @@ module.exports = function createSelectScene(safeInsets, menuRect, onSelect, call
 
   var btnRects = [];
   var infoBtn = null;
+  var hardcoreOn = false;
+  var hardcoreToggleRect = null;
   var helpOpen = false;
   var replayBtn = null;
   var message = '';
@@ -180,6 +182,33 @@ module.exports = function createSelectScene(safeInsets, menuRect, onSelect, call
         btnRects.push({ x: bx, y: y, w: btnW, h: btnH, diff: d });
         y += btnH + btnGap;
       }
+
+      // ── Hardcore mode toggle (per-session; not persisted) ─────────────
+      var hcRowH = 36;
+      var hcTrackW = 56, hcTrackH = 28;
+      var hcKnobR = 11;
+      var hcLabelX = (W - btnW) / 2;
+      var hcTrackX = hcLabelX + btnW - hcTrackW;
+      var hcTrackY = y + (hcRowH - hcTrackH) / 2;
+      // Label
+      R.textBold(ctx, '🔥 硬核模式', hcLabelX, y + hcRowH / 2, 16, '#333', 'left', 'middle');
+      // Track + knob
+      R.roundRect(ctx, hcTrackX, hcTrackY, hcTrackW, hcTrackH, hcTrackH / 2,
+        hardcoreOn ? '#FF7043' : '#BDBDBD');
+      var knobX = hardcoreOn
+        ? hcTrackX + hcTrackW - hcKnobR - 4
+        : hcTrackX + hcKnobR + 4;
+      ctx.beginPath();
+      ctx.arc(knobX, hcTrackY + hcTrackH / 2, hcKnobR, 0, Math.PI * 2);
+      ctx.fillStyle = '#fff';
+      ctx.fill();
+      hardcoreToggleRect = { x: hcLabelX, y: y, w: btnW, h: hcRowH };
+      y += hcRowH + 2;
+      // Caption (small grey)
+      R.text(ctx, '关闭提示・换题・券，重开变为清空棋盘',
+        hcLabelX, y + 8, 11, '#888', 'left');
+      y += 18;
+      // ──────────────────────────────────────────────────────────────────
 
       // Info / rules button (top-right, below capsule menu).
       var iSize = 32;
@@ -371,6 +400,12 @@ module.exports = function createSelectScene(safeInsets, menuRect, onSelect, call
       return;
     }
 
+    if (hardcoreToggleRect && R.hitTest(x, y, hardcoreToggleRect)) {
+      hardcoreOn = !hardcoreOn;
+      scene.dirty = true;
+      return;
+    }
+
     // Difficulty buttons — with temp-slot intercept.
     for (var i = 0; i < btnRects.length; i++) {
       if (R.hitTest(x, y, btnRects[i])) {
@@ -389,7 +424,7 @@ module.exports = function createSelectScene(safeInsets, menuRect, onSelect, call
           showMsg('体力不足！需要 ' + cost + ' 点，当前 ' + stamina.getStamina() + ' 点');
           return;
         }
-        onSelect(d, null, null);
+        onSelect(d, null, { hardcore: hardcoreOn });
         return;
       }
     }

--- a/calendar-puzzle-miniprogram/minigame/js/slotUI.js
+++ b/calendar-puzzle-miniprogram/minigame/js/slotUI.js
@@ -92,6 +92,12 @@ function pickOldestNewest(slots) {
  * Map difficulty key to Chinese label. Unknown keys pass through unchanged.
  * Pulls from puzzleGenerator.DIFFICULTY_CONFIG so labels stay in sync with the game.
  */
+// Returns ' 🔥' when the saved slot was a hardcore run, '' otherwise.
+// Mode is round-tripped via captureState (gameScene.js) and slotStore.
+function hardcoreBadge(slot) {
+  return (slot && slot.mode && slot.mode.hardcore) ? ' 🔥' : '';
+}
+
 function difficultyLabel(diffKey) {
   if (!diffKey) return '';
   var cfg = PG.DIFFICULTY_CONFIG && PG.DIFFICULTY_CONFIG[diffKey];
@@ -337,7 +343,7 @@ function drawSavePicker(ctx, layout, slots, selectedIdx) {
       ctx.lineWidth = borderWidth;
       R.roundRect(ctx, r.x, r.y, r.w, r.h, 8, PANEL_BG, borderColor);
       drawThumbnail(ctx, r.x + 6, r.y + (r.h - 48) / 2, 48, 48, slot);
-      R.textBold(ctx, difficultyLabel(slot.difficulty),
+      R.textBold(ctx, difficultyLabel(slot.difficulty) + hardcoreBadge(slot),
         r.x + 62, r.y + 12, 12, TEXT_DARK, 'left', 'top');
       R.text(ctx, formatSavedAt(slot.savedAt),
         r.x + 62, r.y + 30, 11, '#888888', 'left', 'top');
@@ -389,7 +395,7 @@ function drawOverwriteWarning(ctx, layout, slots, oldestIdx, newestIdx, selected
     }
     if (slot) {
       drawThumbnail(ctx, r.x + 6, r.y + (r.h - 48) / 2, 48, 48, slot);
-      var label = difficultyLabel(slot.difficulty);
+      var label = difficultyLabel(slot.difficulty) + hardcoreBadge(slot);
       if (i === oldestIdx) label += ' (最旧)';
       else if (i === newestIdx) label += ' (最近)';
       R.textBold(ctx, label, r.x + 62, r.y + 12, 12, TEXT_DARK, 'left', 'top');
@@ -434,7 +440,7 @@ function drawContinueDiscard(ctx, layout, unsavedSlot, pendingDifficulty) {
 
   if (unsavedSlot) {
     var infoY = pr.y + pr.h + 8;
-    R.text(ctx, difficultyLabel(unsavedSlot.difficulty) + '  ' + (unsavedSlot.date || ''),
+    R.text(ctx, difficultyLabel(unsavedSlot.difficulty) + hardcoreBadge(unsavedSlot) + '  ' + (unsavedSlot.date || ''),
       p.x + p.w / 2, infoY, 12, '#666666', 'center', 'top');
   }
 
@@ -480,7 +486,7 @@ function drawSlotGrid(ctx, layout, slots) {
       allEmpty = false;
       R.roundRect(ctx, r.x, r.y, r.w, r.h, 10, PANEL_BG, '#DDDDDD');
       drawThumbnail(ctx, r.x + 8, r.y + (r.h - 56) / 2, 56, 56, slot);
-      R.textBold(ctx, difficultyLabel(slot.difficulty),
+      R.textBold(ctx, difficultyLabel(slot.difficulty) + hardcoreBadge(slot),
         r.x + 72, r.y + 14, 13, TEXT_DARK, 'left', 'top');
       R.text(ctx, slot.date || '',
         r.x + 72, r.y + 32, 12, '#888888', 'left', 'top');

--- a/calendar-puzzle-miniprogram/tests/hint.test.js
+++ b/calendar-puzzle-miniprogram/tests/hint.test.js
@@ -400,3 +400,46 @@ test('applyStrong preserves mediumMismatchIgnored when true', function () {
   var res = H.applyStrong(state, 'X-block', palette, dropped, solved);
   assert.strictEqual(res.newState.mediumMismatchIgnored, true, 'flag must survive applyStrong');
 });
+
+function _cellEq(a, b) { return a.x === b.x && a.y === b.y; }
+function _cellsContain(set, c) { for (var i = 0; i < set.length; i++) if (_cellEq(set[i], c)) return true; return false; }
+function _isSubset(sub, sup) { for (var i = 0; i < sub.length; i++) if (!_cellsContain(sup, sub[i])) return false; return true; }
+
+test('findMediumMismatch returns null when mediumLocked is empty', function () {
+  var s = H.createHintState('p-fm-1');
+  var cells = [{ x: 0, y: 0 }, { x: 1, y: 0 }];
+  assert.strictEqual(H.findMediumMismatch(s, 'A-block', cells), null);
+});
+
+test('findMediumMismatch returns null when block covers all its own hint cells', function () {
+  var s = H.createHintState('p-fm-2');
+  s.mediumLocked['A-block'] = [{ x: 2, y: 3 }, { x: 3, y: 3 }];
+  var coversAll = [{ x: 2, y: 3 }, { x: 3, y: 3 }, { x: 4, y: 3 }];
+  assert.strictEqual(H.findMediumMismatch(s, 'A-block', coversAll), null);
+});
+
+test('findMediumMismatch returns right-block-wrong-loc when block misses any own hint cell', function () {
+  var s = H.createHintState('p-fm-3');
+  s.mediumLocked['A-block'] = [{ x: 2, y: 3 }, { x: 3, y: 3 }];
+  var missesOne = [{ x: 2, y: 3 }, { x: 2, y: 4 }];
+  var r = H.findMediumMismatch(s, 'A-block', missesOne);
+  assert.deepStrictEqual(r, { kind: 'right-block-wrong-loc', blockId: 'A-block' });
+});
+
+test('findMediumMismatch returns wrong-block-on-hint when foreign block covers another hint cell', function () {
+  var s = H.createHintState('p-fm-4');
+  s.mediumLocked['A-block'] = [{ x: 2, y: 3 }];
+  var foreign = [{ x: 2, y: 3 }, { x: 3, y: 3 }];
+  var r = H.findMediumMismatch(s, 'B-block', foreign);
+  assert.deepStrictEqual(r, { kind: 'wrong-block-on-hint', placedBlockId: 'B-block', hintedBlockId: 'A-block' });
+});
+
+test('findMediumMismatch prioritises right-block-wrong-loc over wrong-block-on-hint', function () {
+  var s = H.createHintState('p-fm-5');
+  s.mediumLocked['A-block'] = [{ x: 2, y: 3 }, { x: 3, y: 3 }];
+  s.mediumLocked['B-block'] = [{ x: 5, y: 5 }];
+  // A-block is the placed block, misses one of its own cells (3,3), AND covers B-block's (5,5)
+  var weird = [{ x: 2, y: 3 }, { x: 5, y: 5 }];
+  var r = H.findMediumMismatch(s, 'A-block', weird);
+  assert.deepStrictEqual(r, { kind: 'right-block-wrong-loc', blockId: 'A-block' });
+});

--- a/calendar-puzzle-miniprogram/tests/hint.test.js
+++ b/calendar-puzzle-miniprogram/tests/hint.test.js
@@ -443,3 +443,19 @@ test('findMediumMismatch prioritises right-block-wrong-loc over wrong-block-on-h
   var r = H.findMediumMismatch(s, 'A-block', weird);
   assert.deepStrictEqual(r, { kind: 'right-block-wrong-loc', blockId: 'A-block' });
 });
+
+test('findMediumMismatch ignores mediumMismatchIgnored — that flag is the caller\'s guard, not the detector\'s', function () {
+  var s = H.createHintState('p-fm-6');
+  s.mediumLocked['A-block'] = [{ x: 2, y: 3 }];
+  var s2 = H.restoreHintState(Object.assign({}, s, { mediumMismatchIgnored: true }), 'p-fm-6');
+  var r = H.findMediumMismatch(s2, 'B-block', [{ x: 2, y: 3 }]);
+  assert.deepStrictEqual(r, { kind: 'wrong-block-on-hint', placedBlockId: 'B-block', hintedBlockId: 'A-block' });
+});
+
+test('findMediumMismatch returns null for null/empty blockCells', function () {
+  var s = H.createHintState('p-fm-7');
+  s.mediumLocked['A-block'] = [{ x: 2, y: 3 }];
+  assert.strictEqual(H.findMediumMismatch(s, 'A-block', null), null);
+  assert.strictEqual(H.findMediumMismatch(s, 'A-block', undefined), null);
+  assert.strictEqual(H.findMediumMismatch(s, 'A-block', []), null);
+});

--- a/calendar-puzzle-miniprogram/tests/hint.test.js
+++ b/calendar-puzzle-miniprogram/tests/hint.test.js
@@ -347,3 +347,20 @@ test('restoreHintState: strong-locked block stays locked after restore (regressi
   assert.strictEqual(H.isFullyLocked(restored, 'X-block'), true, 'strong-locked block must remain locked after reload');
   assert.strictEqual(H.canUse(restored, 'strong'), false, 'strong-hint cap (1) must remain enforced after reload');
 });
+
+test('createHintState initialises mediumMismatchIgnored to false', function () {
+  var s = H.createHintState('p-mm-1');
+  assert.strictEqual(s.mediumMismatchIgnored, false);
+});
+
+test('restoreHintState defaults mediumMismatchIgnored to false when absent', function () {
+  var saved = { puzzleId: 'p-mm-rt-1', weakLocked: {}, mediumLocked: {}, strongLocked: {}, usedWeak: 0, usedMedium: 0, usedStrong: 0 };
+  var s = H.restoreHintState(saved, 'p-mm-rt-1');
+  assert.strictEqual(s.mediumMismatchIgnored, false);
+});
+
+test('restoreHintState round-trips mediumMismatchIgnored: true', function () {
+  var saved = { puzzleId: 'p-mm-rt-2', weakLocked: {}, mediumLocked: {}, strongLocked: {}, usedWeak: 0, usedMedium: 0, usedStrong: 0, mediumMismatchIgnored: true };
+  var s = H.restoreHintState(saved, 'p-mm-rt-2');
+  assert.strictEqual(s.mediumMismatchIgnored, true);
+});

--- a/calendar-puzzle-miniprogram/tests/hint.test.js
+++ b/calendar-puzzle-miniprogram/tests/hint.test.js
@@ -364,3 +364,33 @@ test('restoreHintState round-trips mediumMismatchIgnored: true', function () {
   var s = H.restoreHintState(saved, 'p-mm-rt-2');
   assert.strictEqual(s.mediumMismatchIgnored, true);
 });
+
+test('applyWeak preserves mediumMismatchIgnored when true', function () {
+  var state = H.createHintState('p-prop-1');
+  state.mediumMismatchIgnored = true;
+  var palette = [{ id: 'X-block', label: 'X', shape: [[1, 1], [0, 1]] }];
+  var dropped = [];
+  var solved = { 'X-block': { x: 0, y: 0, shape: [[1, 0], [1, 1]] } };
+  var res = H.applyWeak(state, 'X-block', palette, dropped, solved);
+  assert.strictEqual(res.newState.mediumMismatchIgnored, true, 'flag must survive applyWeak');
+});
+
+test('applyMedium preserves mediumMismatchIgnored when true', function () {
+  var state = H.createHintState('p-prop-2');
+  state.mediumMismatchIgnored = true;
+  var palette = [{ id: 'X-block', label: 'X', shape: [[1, 1]] }];
+  var dropped = [];
+  var solved = { 'X-block': { x: 2, y: 3, shape: [[1, 1]] } };
+  var res = H.applyMedium(state, 'X-block', palette, dropped, solved);
+  assert.strictEqual(res.newState.mediumMismatchIgnored, true, 'flag must survive applyMedium');
+});
+
+test('applyStrong preserves mediumMismatchIgnored when true', function () {
+  var state = H.createHintState('p-prop-3');
+  state.mediumMismatchIgnored = true;
+  var palette = [{ id: 'X-block', label: 'X', shape: [[1, 1]] }];
+  var dropped = [];
+  var solved = { 'X-block': { x: 2, y: 3, shape: [[1, 1]] } };
+  var res = H.applyStrong(state, 'X-block', palette, dropped, solved);
+  assert.strictEqual(res.newState.mediumMismatchIgnored, true, 'flag must survive applyStrong');
+});

--- a/calendar-puzzle-miniprogram/tests/hint.test.js
+++ b/calendar-puzzle-miniprogram/tests/hint.test.js
@@ -365,9 +365,17 @@ test('restoreHintState round-trips mediumMismatchIgnored: true', function () {
   assert.strictEqual(s.mediumMismatchIgnored, true);
 });
 
+function _stateWithIgnored(puzzleId) {
+  return H.restoreHintState({
+    puzzleId: puzzleId,
+    weakLocked: {}, mediumLocked: {}, strongLocked: {},
+    usedWeak: 0, usedMedium: 0, usedStrong: 0,
+    mediumMismatchIgnored: true,
+  }, puzzleId);
+}
+
 test('applyWeak preserves mediumMismatchIgnored when true', function () {
-  var state = H.createHintState('p-prop-1');
-  state.mediumMismatchIgnored = true;
+  var state = _stateWithIgnored('p-prop-1');
   var palette = [{ id: 'X-block', label: 'X', shape: [[1, 1], [0, 1]] }];
   var dropped = [];
   var solved = { 'X-block': { x: 0, y: 0, shape: [[1, 0], [1, 1]] } };
@@ -376,8 +384,7 @@ test('applyWeak preserves mediumMismatchIgnored when true', function () {
 });
 
 test('applyMedium preserves mediumMismatchIgnored when true', function () {
-  var state = H.createHintState('p-prop-2');
-  state.mediumMismatchIgnored = true;
+  var state = _stateWithIgnored('p-prop-2');
   var palette = [{ id: 'X-block', label: 'X', shape: [[1, 1]] }];
   var dropped = [];
   var solved = { 'X-block': { x: 2, y: 3, shape: [[1, 1]] } };
@@ -386,8 +393,7 @@ test('applyMedium preserves mediumMismatchIgnored when true', function () {
 });
 
 test('applyStrong preserves mediumMismatchIgnored when true', function () {
-  var state = H.createHintState('p-prop-3');
-  state.mediumMismatchIgnored = true;
+  var state = _stateWithIgnored('p-prop-3');
   var palette = [{ id: 'X-block', label: 'X', shape: [[1, 1]] }];
   var dropped = [];
   var solved = { 'X-block': { x: 2, y: 3, shape: [[1, 1]] } };

--- a/calendar-puzzle-miniprogram/tests/hint.test.js
+++ b/calendar-puzzle-miniprogram/tests/hint.test.js
@@ -459,3 +459,11 @@ test('findMediumMismatch returns null for null/empty blockCells', function () {
   assert.strictEqual(H.findMediumMismatch(s, 'A-block', undefined), null);
   assert.strictEqual(H.findMediumMismatch(s, 'A-block', []), null);
 });
+
+test('setMediumMismatchIgnored returns new state with flag true, original untouched', function () {
+  var s = H.createHintState('p-set-1');
+  var s2 = H.setMediumMismatchIgnored(s);
+  assert.strictEqual(s2.mediumMismatchIgnored, true);
+  assert.strictEqual(s.mediumMismatchIgnored, false, 'original state must not be mutated');
+  assert.notStrictEqual(s2, s, 'must return a new object reference');
+});

--- a/calendar-puzzle-miniprogram/tests/mode.test.js
+++ b/calendar-puzzle-miniprogram/tests/mode.test.js
@@ -1,0 +1,49 @@
+var test = require('node:test');
+var assert = require('node:assert');
+var M = require('../minigame/js/mode');
+
+test('createMode(): empty/missing opts → { hardcore: false }', function () {
+  assert.deepStrictEqual(M.createMode(),         { hardcore: false });
+  assert.deepStrictEqual(M.createMode(undefined),{ hardcore: false });
+  assert.deepStrictEqual(M.createMode(null),     { hardcore: false });
+  assert.deepStrictEqual(M.createMode({}),       { hardcore: false });
+});
+
+test('createMode(): truthy hardcore opt → { hardcore: true }; coerced to boolean', function () {
+  assert.deepStrictEqual(M.createMode({ hardcore: true }),  { hardcore: true });
+  assert.deepStrictEqual(M.createMode({ hardcore: 1 }),     { hardcore: true });
+  assert.deepStrictEqual(M.createMode({ hardcore: false }), { hardcore: false });
+  assert.deepStrictEqual(M.createMode({ hardcore: 0 }),     { hardcore: false });
+});
+
+test('createMode(): ignores unknown opts (forward-compat)', function () {
+  assert.deepStrictEqual(M.createMode({ hardcore: true, ghost: 'ignored' }), { hardcore: true });
+});
+
+test('isHardcore(): true only when mode.hardcore === true', function () {
+  assert.strictEqual(M.isHardcore(undefined),                 false);
+  assert.strictEqual(M.isHardcore(null),                      false);
+  assert.strictEqual(M.isHardcore({}),                        false);
+  assert.strictEqual(M.isHardcore({ hardcore: false }),       false);
+  assert.strictEqual(M.isHardcore({ hardcore: true }),        true);
+});
+
+test('canUseHint / canSwapPuzzle / canRestart: false in hardcore, true otherwise', function () {
+  var hc = M.createMode({ hardcore: true });
+  var nm = M.createMode({});
+  assert.strictEqual(M.canUseHint(hc),    false);
+  assert.strictEqual(M.canUseHint(nm),    true);
+  assert.strictEqual(M.canSwapPuzzle(hc), false);
+  assert.strictEqual(M.canSwapPuzzle(nm), true);
+  assert.strictEqual(M.canRestart(hc),    false);
+  assert.strictEqual(M.canRestart(nm),    true);
+});
+
+test('canClearBoard: true regardless of mode', function () {
+  assert.strictEqual(M.canClearBoard(M.createMode({ hardcore: true })),  true);
+  assert.strictEqual(M.canClearBoard(M.createMode({ hardcore: false })), true);
+});
+
+test('DEFAULT_MODE is the canonical { hardcore: false }', function () {
+  assert.deepStrictEqual(M.DEFAULT_MODE, { hardcore: false });
+});

--- a/calendar-puzzle-miniprogram/tests/progress.hardcore.test.js
+++ b/calendar-puzzle-miniprogram/tests/progress.hardcore.test.js
@@ -1,0 +1,54 @@
+var test = require('node:test');
+var assert = require('node:assert');
+
+// Install a fresh in-memory wx shim BEFORE requiring the module, since
+// progress.js does not DI the storage layer.
+function installWX() {
+  global.wx = {
+    _s: {},
+    setStorageSync: function (k, v) { this._s[k] = v; },
+    getStorageSync: function (k) { return k in this._s ? this._s[k] : ''; },
+  };
+}
+function resetWX() { if (global.wx) global.wx._s = {}; }
+
+installWX();
+var progress = require('../minigame/js/progress');
+
+test('markHardcoreCleared: first time at (date, difficulty) returns true and persists', function () {
+  resetWX();
+  assert.strictEqual(progress.markHardcoreCleared('2026-05-27', 'expert'), true);
+  assert.strictEqual(progress.hasHardcoreCleared('2026-05-27', 'expert'), true);
+});
+
+test('markHardcoreCleared: idempotent — second call at same (date, difficulty) returns false', function () {
+  resetWX();
+  progress.markHardcoreCleared('2026-05-27', 'expert');
+  assert.strictEqual(progress.markHardcoreCleared('2026-05-27', 'expert'), false);
+  assert.strictEqual(progress.hasHardcoreCleared('2026-05-27', 'expert'), true);
+});
+
+test('markHardcoreCleared: distinct (difficulty) on same date both record', function () {
+  resetWX();
+  assert.strictEqual(progress.markHardcoreCleared('2026-05-27', 'easy'),   true);
+  assert.strictEqual(progress.markHardcoreCleared('2026-05-27', 'expert'), true);
+  assert.strictEqual(progress.hasHardcoreCleared('2026-05-27', 'easy'),    true);
+  assert.strictEqual(progress.hasHardcoreCleared('2026-05-27', 'expert'),  true);
+});
+
+test('hasHardcoreCleared: false when never marked / different date / different difficulty', function () {
+  resetWX();
+  assert.strictEqual(progress.hasHardcoreCleared('2026-05-27', 'expert'), false);
+  progress.markHardcoreCleared('2026-05-27', 'expert');
+  assert.strictEqual(progress.hasHardcoreCleared('2026-05-28', 'expert'), false);
+  assert.strictEqual(progress.hasHardcoreCleared('2026-05-27', 'hard'),   false);
+});
+
+test('storage round-trip: hardcoreDays survives a fresh require-cycle via wx storage', function () {
+  resetWX();
+  progress.markHardcoreCleared('2026-05-27', 'insomnia');
+  // Drop the cached module so the next require re-reads wx storage.
+  delete require.cache[require.resolve('../minigame/js/progress')];
+  var progress2 = require('../minigame/js/progress');
+  assert.strictEqual(progress2.hasHardcoreCleared('2026-05-27', 'insomnia'), true);
+});

--- a/calendar-puzzle-miniprogram/tests/slotStore.test.js
+++ b/calendar-puzzle-miniprogram/tests/slotStore.test.js
@@ -230,3 +230,35 @@ test('slotStore: nested hintState (weak/medium/strong locks + used counters) rou
   assert.strictEqual(got.hintState.mediumLocked['Y-block'].length, 2);
   assert.strictEqual(got.hintState.usedStrong, 1);
 });
+
+test('slotStore: mode field round-trips on writeSlot/readSlot', function () {
+  var s = fakeStorage();
+  var ss = SS.create({ storage: s, now: function () { return 1716181000000; } });
+  ss.writeSlot('named-1', {
+    date: '2026-05-27',
+    difficulty: 'expert',
+    comboIndex: 1,
+    placedBlocks: [],
+    paletteBlocks: [],
+    elapsedMs: 0,
+    mode: { hardcore: true },
+  });
+  var got = ss.readSlot('named-1');
+  assert.deepStrictEqual(got.mode, { hardcore: true });
+});
+
+test('slotStore: legacy payload without mode reads back without a mode field (caller defaults)', function () {
+  var s = fakeStorage();
+  var ss = SS.create({ storage: s, now: function () { return 1716181000000; } });
+  ss.writeSlot('named-1', {
+    date: '2026-05-27',
+    difficulty: 'easy',
+    comboIndex: 0,
+    placedBlocks: [],
+    paletteBlocks: [],
+    elapsedMs: 0,
+    // no mode field
+  });
+  var got = ss.readSlot('named-1');
+  assert.strictEqual(got.mode, undefined);
+});

--- a/docs/superpowers/plans/2026-05-27-hardcore-mode.md
+++ b/docs/superpowers/plans/2026-05-27-hardcore-mode.md
@@ -1,0 +1,1179 @@
+# Hardcore Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a cross-difficulty "硬核模式" toggle to the WeChat minigame: disables hint / random-switch / picker buttons, replaces "重开" with a timer-preserving "清空", introduces a pause-menu (☰) with a one-way "放弃硬核" downgrade, and records per-day per-difficulty hardcore clears in `progress`.
+
+**Architecture:** A new `mode.js` module owns `{ hardcore: bool }` plus capability helpers (`canUseHint`, `canSwapPuzzle`, `canRestart`). The flag threads `selectScene → main.js → gameScene` through the existing callback chain, and round-trips into save slots via `captureState`. Per-day per-difficulty hardcore clears live in `progress.js` under a new `hardcoreDays` storage key. UI changes are scoped to `selectScene` (toggle row) and `gameScene` (control-row layout + new ☰ sheet).
+
+**Tech Stack:** WeChat minigame (`calendar-puzzle-miniprogram/minigame/`), plain JS, `node --test` for units, `wx.*StorageSync` for persistence.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-27-hardcore-mode-design.md`.
+
+**Base branch:** `feature/medium-hint-mismatch-dialog`. Suggested implementation branch: `feature/hardcore-mode`.
+
+**Repo-root note:** All `Run:` commands assume cwd = `calendar-puzzle-miniprogram/` (where `package.json` and `tests/` live). All file paths in this plan are relative to the **repo root** (`/Users/bytedance/mygit/CalendarPuzzle/`) for `git add` precision.
+
+---
+
+## File Structure
+
+| File | Purpose | Action |
+|---|---|---|
+| `calendar-puzzle-miniprogram/minigame/js/mode.js` | Mode object factory + capability helpers | **Create** |
+| `calendar-puzzle-miniprogram/tests/mode.test.js` | Unit tests for mode module | **Create** |
+| `calendar-puzzle-miniprogram/minigame/js/progress.js` | Add `markHardcoreCleared` / `hasHardcoreCleared` + new storage key | **Modify** |
+| `calendar-puzzle-miniprogram/tests/progress.hardcore.test.js` | Unit tests for hardcoreDays (no existing `progress.test.js`) | **Create** |
+| `calendar-puzzle-miniprogram/minigame/js/main.js` | Thread `modeOpts` through `goToSelect` → `startGame` → `launchGameScene` → `createGameScene` | **Modify** |
+| `calendar-puzzle-miniprogram/minigame/js/selectScene.js` | Hardcore toggle row UI + state + hit handler + extend `onSelect` signature | **Modify** |
+| `calendar-puzzle-miniprogram/minigame/js/gameScene.js` | Mode property + control-row gating + `clearBoardKeepTimer` + ☰ pause menu + `markHardcoreCleared` call + win-modal label | **Modify** |
+| `calendar-puzzle-miniprogram/tests/slotStore.test.js` | +2 cases: `mode` round-trip and old-payload absence | **Modify** |
+| `calendar-puzzle-miniprogram/minigame/CHANGELOG.md` | `[0.7.0] — 2026-05-27` entry | **Modify** |
+
+`gameScene.js` already lacks integration tests (per `session-handoff.md`: *"`createGameScene(savedState)` 至今无集成测试"*); gameScene-touching tasks therefore rely on `node --check` for syntax + the existing unit test surface for no-regression, plus the manual smoke matrix in §6.2 of the spec.
+
+---
+
+## Task 1: Mode module + capability helpers
+
+**Files:**
+- Create: `calendar-puzzle-miniprogram/minigame/js/mode.js`
+- Create: `calendar-puzzle-miniprogram/tests/mode.test.js`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `calendar-puzzle-miniprogram/tests/mode.test.js`:
+
+```js
+var test = require('node:test');
+var assert = require('node:assert');
+var M = require('../minigame/js/mode');
+
+test('createMode(): empty/missing opts → { hardcore: false }', function () {
+  assert.deepStrictEqual(M.createMode(),         { hardcore: false });
+  assert.deepStrictEqual(M.createMode(undefined),{ hardcore: false });
+  assert.deepStrictEqual(M.createMode(null),     { hardcore: false });
+  assert.deepStrictEqual(M.createMode({}),       { hardcore: false });
+});
+
+test('createMode(): truthy hardcore opt → { hardcore: true }; coerced to boolean', function () {
+  assert.deepStrictEqual(M.createMode({ hardcore: true }),  { hardcore: true });
+  assert.deepStrictEqual(M.createMode({ hardcore: 1 }),     { hardcore: true });
+  assert.deepStrictEqual(M.createMode({ hardcore: false }), { hardcore: false });
+  assert.deepStrictEqual(M.createMode({ hardcore: 0 }),     { hardcore: false });
+});
+
+test('createMode(): ignores unknown opts (forward-compat)', function () {
+  assert.deepStrictEqual(M.createMode({ hardcore: true, ghost: 'ignored' }), { hardcore: true });
+});
+
+test('isHardcore(): true only when mode.hardcore === true', function () {
+  assert.strictEqual(M.isHardcore(undefined),                 false);
+  assert.strictEqual(M.isHardcore(null),                      false);
+  assert.strictEqual(M.isHardcore({}),                        false);
+  assert.strictEqual(M.isHardcore({ hardcore: false }),       false);
+  assert.strictEqual(M.isHardcore({ hardcore: true }),        true);
+});
+
+test('canUseHint / canSwapPuzzle / canRestart: false in hardcore, true otherwise', function () {
+  var hc = M.createMode({ hardcore: true });
+  var nm = M.createMode({});
+  assert.strictEqual(M.canUseHint(hc),    false);
+  assert.strictEqual(M.canUseHint(nm),    true);
+  assert.strictEqual(M.canSwapPuzzle(hc), false);
+  assert.strictEqual(M.canSwapPuzzle(nm), true);
+  assert.strictEqual(M.canRestart(hc),    false);
+  assert.strictEqual(M.canRestart(nm),    true);
+});
+
+test('canClearBoard: true regardless of mode', function () {
+  assert.strictEqual(M.canClearBoard(M.createMode({ hardcore: true })),  true);
+  assert.strictEqual(M.canClearBoard(M.createMode({ hardcore: false })), true);
+});
+
+test('DEFAULT_MODE is the canonical { hardcore: false }', function () {
+  assert.deepStrictEqual(M.DEFAULT_MODE, { hardcore: false });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `calendar-puzzle-miniprogram/`):
+```bash
+node --test tests/mode.test.js
+```
+Expected: FAIL with `Cannot find module '../minigame/js/mode'` (or similar require error).
+
+- [ ] **Step 3: Create the implementation**
+
+Create `calendar-puzzle-miniprogram/minigame/js/mode.js`:
+
+```js
+// Mode object lives on gameScene and rides save-slot payloads.
+//
+// Capability helpers are the single source of truth for "what does this
+// mode allow"; gameScene render/hit-test branches consult them instead of
+// hard-coding `mode.hardcore`. Future modes (timed, daily-challenge) extend
+// this same surface.
+
+var DEFAULT_MODE = { hardcore: false };
+
+function createMode(opts) {
+  opts = opts || {};
+  return { hardcore: !!opts.hardcore };
+}
+
+function isHardcore(mode) {
+  return !!(mode && mode.hardcore);
+}
+
+function canUseHint(mode)    { return !isHardcore(mode); }
+function canSwapPuzzle(mode) { return !isHardcore(mode); }
+function canRestart(mode)    { return !isHardcore(mode); }
+function canClearBoard(mode) { return true; }
+
+module.exports = {
+  DEFAULT_MODE: DEFAULT_MODE,
+  createMode: createMode,
+  isHardcore: isHardcore,
+  canUseHint: canUseHint,
+  canSwapPuzzle: canSwapPuzzle,
+  canRestart: canRestart,
+  canClearBoard: canClearBoard,
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+node --test tests/mode.test.js
+```
+Expected: all 7 tests pass.
+
+- [ ] **Step 5: Run full suite to confirm no regression**
+
+Run:
+```bash
+npm test
+```
+Expected: prior pass count + 7 (the new tests). Should still be all-green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/mode.js calendar-puzzle-miniprogram/tests/mode.test.js
+git commit -m "feat(minigame/mode): mode module + capability helpers (hardcore foundation)"
+```
+
+---
+
+## Task 2: progress.hardcoreDays — per-date per-difficulty clears
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/progress.js`
+- Create: `calendar-puzzle-miniprogram/tests/progress.hardcore.test.js`
+
+`progress.js` directly calls `wx.getStorageSync` / `wx.setStorageSync`; tests mock these on `global.wx` and reset between cases.
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `calendar-puzzle-miniprogram/tests/progress.hardcore.test.js`:
+
+```js
+var test = require('node:test');
+var assert = require('node:assert');
+
+// Install a fresh in-memory wx shim BEFORE requiring the module, since
+// progress.js does not DI the storage layer.
+function installWX() {
+  global.wx = {
+    _s: {},
+    setStorageSync: function (k, v) { this._s[k] = v; },
+    getStorageSync: function (k) { return k in this._s ? this._s[k] : ''; },
+  };
+}
+function resetWX() { if (global.wx) global.wx._s = {}; }
+
+installWX();
+var progress = require('../minigame/js/progress');
+
+test('markHardcoreCleared: first time at (date, difficulty) returns true and persists', function () {
+  resetWX();
+  assert.strictEqual(progress.markHardcoreCleared('2026-05-27', 'expert'), true);
+  assert.strictEqual(progress.hasHardcoreCleared('2026-05-27', 'expert'), true);
+});
+
+test('markHardcoreCleared: idempotent — second call at same (date, difficulty) returns false', function () {
+  resetWX();
+  progress.markHardcoreCleared('2026-05-27', 'expert');
+  assert.strictEqual(progress.markHardcoreCleared('2026-05-27', 'expert'), false);
+  assert.strictEqual(progress.hasHardcoreCleared('2026-05-27', 'expert'), true);
+});
+
+test('markHardcoreCleared: distinct (difficulty) on same date both record', function () {
+  resetWX();
+  assert.strictEqual(progress.markHardcoreCleared('2026-05-27', 'easy'),   true);
+  assert.strictEqual(progress.markHardcoreCleared('2026-05-27', 'expert'), true);
+  assert.strictEqual(progress.hasHardcoreCleared('2026-05-27', 'easy'),    true);
+  assert.strictEqual(progress.hasHardcoreCleared('2026-05-27', 'expert'),  true);
+});
+
+test('hasHardcoreCleared: false when never marked / different date / different difficulty', function () {
+  resetWX();
+  assert.strictEqual(progress.hasHardcoreCleared('2026-05-27', 'expert'), false);
+  progress.markHardcoreCleared('2026-05-27', 'expert');
+  assert.strictEqual(progress.hasHardcoreCleared('2026-05-28', 'expert'), false);
+  assert.strictEqual(progress.hasHardcoreCleared('2026-05-27', 'hard'),   false);
+});
+
+test('storage round-trip: hardcoreDays survives a fresh require-cycle via wx storage', function () {
+  resetWX();
+  progress.markHardcoreCleared('2026-05-27', 'insomnia');
+  // Drop the cached module so the next require re-reads wx storage.
+  delete require.cache[require.resolve('../minigame/js/progress')];
+  var progress2 = require('../minigame/js/progress');
+  assert.strictEqual(progress2.hasHardcoreCleared('2026-05-27', 'insomnia'), true);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+node --test tests/progress.hardcore.test.js
+```
+Expected: FAIL with `TypeError: progress.markHardcoreCleared is not a function`.
+
+- [ ] **Step 3: Add storage block + functions to `progress.js`**
+
+In `calendar-puzzle-miniprogram/minigame/js/progress.js`, insert after the `markUniqueInsomnia` block (after the line that ends `return { isNew: true, count: arr.length };` plus its closing brace; before the `TUTORIAL_KEY` block):
+
+```js
+// Hardcore mode: per-day per-difficulty clear flag.
+// Storage shape: { "2026-05-27": { "expert": true, "easy": true }, ... }
+var HARDCORE_KEY = 'calendarPuzzleHardcoreDays';
+
+function loadHardcore() {
+  try { var r = wx.getStorageSync(HARDCORE_KEY); if (r) return JSON.parse(r); } catch (e) {}
+  return {};
+}
+
+function saveHardcore(d) {
+  try { wx.setStorageSync(HARDCORE_KEY, JSON.stringify(d)); } catch (e) {}
+}
+
+// Returns true on first-time-at-this-(date, difficulty); false if already set.
+function markHardcoreCleared(dateStr, difficulty) {
+  if (!dateStr || !difficulty) return false;
+  var all = loadHardcore();
+  var entry = all[dateStr] = all[dateStr] || {};
+  if (entry[difficulty]) return false;
+  entry[difficulty] = true;
+  saveHardcore(all);
+  return true;
+}
+
+function hasHardcoreCleared(dateStr, difficulty) {
+  if (!dateStr || !difficulty) return false;
+  var all = loadHardcore();
+  var entry = all[dateStr];
+  return !!(entry && entry[difficulty]);
+}
+```
+
+Then add to the `module.exports = { ... };` block at the bottom of the file (before the closing `};`):
+
+```js
+  markHardcoreCleared: markHardcoreCleared,
+  hasHardcoreCleared: hasHardcoreCleared,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+```bash
+node --test tests/progress.hardcore.test.js
+```
+Expected: all 5 tests pass.
+
+- [ ] **Step 5: Run full suite**
+
+Run:
+```bash
+npm test
+```
+Expected: no regression; total pass count += 5.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/progress.js calendar-puzzle-miniprogram/tests/progress.hardcore.test.js
+git commit -m "feat(minigame/progress): hardcoreDays — per-date per-difficulty clear tracking"
+```
+
+---
+
+## Task 3: Thread mode through main.js → selectScene → gameScene + captureState round-trip
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/main.js`
+- Modify: `calendar-puzzle-miniprogram/minigame/js/selectScene.js` (signature only — UI work is Task 4)
+- Modify: `calendar-puzzle-miniprogram/minigame/js/gameScene.js`
+- Modify: `calendar-puzzle-miniprogram/tests/slotStore.test.js`
+
+Threading plan:
+- `selectScene` callback `onSelect(difficulty, savedState)` → `onSelect(difficulty, savedState, modeOpts)`. (Task 5 fills the toggle UI; this task only widens the signature with `modeOpts = null` at all call sites.)
+- `main.js` `startGame(d, savedState)` → `startGame(d, savedState, modeOpts)`; `launchGameScene(d, puzzle, savedState)` → `launchGameScene(d, puzzle, savedState, modeOpts)`.
+- `gameScene.js`: append `modeOpts` as 7th positional arg to `createGameScene(...)`; resolve `this.mode = M.createMode(savedState && savedState.mode ? savedState.mode : modeOpts)` near scene init; include `mode: scene.mode` in `captureState()`.
+
+- [ ] **Step 1: Write the failing slotStore test cases**
+
+Open `calendar-puzzle-miniprogram/tests/slotStore.test.js` and append at the bottom of the file:
+
+```js
+test('slotStore: mode field round-trips on writeSlot/readSlot', function () {
+  var s = fakeStorage();
+  var ss = SS.create({ storage: s, now: function () { return 1716181000000; } });
+  ss.writeSlot('named-1', {
+    date: '2026-05-27',
+    difficulty: 'expert',
+    comboIndex: 1,
+    placedBlocks: [],
+    paletteBlocks: [],
+    elapsedMs: 0,
+    mode: { hardcore: true },
+  });
+  var got = ss.readSlot('named-1');
+  assert.deepStrictEqual(got.mode, { hardcore: true });
+});
+
+test('slotStore: legacy payload without mode reads back without a mode field (caller defaults)', function () {
+  var s = fakeStorage();
+  var ss = SS.create({ storage: s, now: function () { return 1716181000000; } });
+  ss.writeSlot('named-1', {
+    date: '2026-05-27',
+    difficulty: 'easy',
+    comboIndex: 0,
+    placedBlocks: [],
+    paletteBlocks: [],
+    elapsedMs: 0,
+    // no mode field
+  });
+  var got = ss.readSlot('named-1');
+  assert.strictEqual(got.mode, undefined);
+});
+```
+
+- [ ] **Step 2: Run only the new slotStore tests to verify mode round-trip already works (or fails)**
+
+Run:
+```bash
+node --test tests/slotStore.test.js
+```
+Expected: **both new tests PASS** without code changes — `slotStore` is schemaless (it stores whatever payload is given). If they fail with field-stripping, jump to Step 3a (otherwise skip 3a).
+
+  > Step 3a (only if Step 2's first new test fails): open `calendar-puzzle-miniprogram/minigame/js/slotStore.js`, find any field-whitelist or normalization in `writeSlot`/`readSlot`, and add `mode` to the allow-list. Then re-run.
+
+- [ ] **Step 3: Modify `gameScene.js` — accept modeOpts, resolve scene.mode, include in captureState**
+
+In `calendar-puzzle-miniprogram/minigame/js/gameScene.js`:
+
+**3a.** Near the top of the file, find the require block (search for `require('./hint')` to land in it). Add directly under it:
+
+```js
+var M = require('./mode');
+```
+
+**3b.** Change the export signature at line 46 from:
+
+```js
+module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRect, callbacks, savedState) {
+```
+
+to:
+
+```js
+module.exports = function createGameScene(difficulty, puzzle, safeInsets, menuRect, callbacks, savedState, modeOpts) {
+```
+
+**3c.** Find the `if (savedState) { ... }` block (starts around line 72). Immediately after that block ends (before the next non-blank line that introduces new logic — look for the next `var hintState =` around line 131; insert above any reads of `hintState`), add:
+
+```js
+  // Mode resolution: a restored save carries its own mode (preserves hardcore
+  // across exit/resume); a fresh game receives modeOpts from selectScene; the
+  // implicit default is non-hardcore.
+  var mode = M.createMode(savedState && savedState.mode ? savedState.mode : modeOpts);
+  scene.mode = mode;
+```
+
+(Place this above `var hintState = Hint.restoreHintState(...)` so later code in this task / future tasks can read `mode` freely.)
+
+**3d.** Find `function captureState()` (line 149). Inside the returned object literal, add `mode: mode,` as a new key. The result should look like:
+
+```js
+  function captureState() {
+    return {
+      boundSlotId: _slotBinding.getBound(),
+      date: puzzle.dateStr,
+      difficulty: difficulty,
+      comboIndex: puzzle.currentComboIndex,
+      placedBlocks: dropped.map(B.cloneBlock),
+      paletteBlocks: palette.map(B.cloneBlock),
+      prePlacedBlocks: prePlaced.map(B.cloneBlock),
+      elapsedMs: timer * 1000,
+      hintState: hintState,
+      playedCombos: Object.assign({}, playedCombos),
+      mode: mode,
+    };
+  }
+```
+
+- [ ] **Step 4: Modify `selectScene.js` — widen onSelect signature with explicit null modeOpts at every call site**
+
+In `calendar-puzzle-miniprogram/minigame/js/selectScene.js`, find each of the 4 `onSelect(...)` call sites (verified at lines 298, 315, 342, 392 in the current branch — re-run `grep -n "onSelect(" minigame/js/selectScene.js` if line numbers have drifted). For now, append `, null` to each call as a placeholder. The toggle wiring in Task 5 will replace the last call site's `null` with a real value.
+
+Examples:
+- `onSelect(saved.difficulty, saved);`         → `onSelect(saved.difficulty, saved, null);`
+- `onSelect(pd, null);`                         → `onSelect(pd, null, null);`
+- `onSelect(slotPayload.difficulty, slotPayload);` → `onSelect(slotPayload.difficulty, slotPayload, null);`
+- `onSelect(d, null);`                          → `onSelect(d, null, null);`
+
+- [ ] **Step 5: Modify `main.js` — thread modeOpts through `goToSelect → startGame → launchGameScene → createGameScene`**
+
+In `calendar-puzzle-miniprogram/minigame/js/main.js`:
+
+**5a.** At line ~173 (`createSelectScene` callback), change:
+
+```js
+  currentScene = createSelectScene(safeInsets, menuRect, function (difficulty, savedState) {
+    startGame(difficulty, savedState);
+  }, {
+```
+
+to:
+
+```js
+  currentScene = createSelectScene(safeInsets, menuRect, function (difficulty, savedState, modeOpts) {
+    startGame(difficulty, savedState, modeOpts);
+  }, {
+```
+
+**5b.** Change the `startGame` function signature and pass-through:
+
+```js
+function startGame(difficulty, savedState) {
+```
+→
+```js
+function startGame(difficulty, savedState, modeOpts) {
+```
+
+And at the end of `startGame`, change:
+```js
+    launchGameScene(difficulty, puzzle, savedState);
+```
+→
+```js
+    launchGameScene(difficulty, puzzle, savedState, modeOpts);
+```
+
+**5c.** Change `launchGameScene` signature and the final `createGameScene` call:
+
+```js
+function launchGameScene(difficulty, puzzle, savedState) {
+```
+→
+```js
+function launchGameScene(difficulty, puzzle, savedState, modeOpts) {
+```
+
+And the `createGameScene(...)` invocation (currently lines ~208-219) ends with `}, savedState);`. Change the final arg to `}, savedState, modeOpts);`.
+
+**5d.** Find the `onSwitchPuzzle` callback inside `launchGameScene` (line ~210):
+
+```js
+    onSwitchPuzzle: function (newPuzzle) {
+      launchGameScene(difficulty, newPuzzle);
+    },
+```
+
+Change to:
+```js
+    onSwitchPuzzle: function (newPuzzle) {
+      launchGameScene(difficulty, newPuzzle, null, scene.mode || null);
+    },
+```
+
+Rationale: when the player taps 🎲 / 🎯, the new game inherits the current scene's mode. (In hardcore those buttons are hidden, so this branch only ever fires with non-hardcore mode — but we forward defensively anyway.) Note: `scene` is the local var holding the current gameScene returned by `createGameScene(...)`; verify by `grep -n "currentScene = createGameScene\|var scene " minigame/js/main.js`. If `scene` is not in scope here, use `currentScene.mode` (currentScene is reassigned just above).
+
+- [ ] **Step 6: Syntax check + full test suite**
+
+Run:
+```bash
+node --check minigame/js/mode.js
+node --check minigame/js/gameScene.js
+node --check minigame/js/selectScene.js
+node --check minigame/js/main.js
+node --check minigame/js/progress.js
+npm test
+```
+Expected: all `node --check` exit 0; `npm test` green; new slotStore cases pass (+2); no regression elsewhere.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add \
+  calendar-puzzle-miniprogram/minigame/js/main.js \
+  calendar-puzzle-miniprogram/minigame/js/selectScene.js \
+  calendar-puzzle-miniprogram/minigame/js/gameScene.js \
+  calendar-puzzle-miniprogram/tests/slotStore.test.js
+git commit -m "feat(minigame/mode): thread mode through main→selectScene→gameScene + captureState round-trip"
+```
+
+---
+
+## Task 4: selectScene — hardcore toggle row UI + per-session state
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/selectScene.js`
+
+The toggle is rendered immediately below the 5 difficulty buttons (after the `for` loop that pushes to `btnRects`, before the info-button `ⓘ` block). State is held in scope-local `var hardcoreOn = false;` — **never** read/written to storage (per-session intent).
+
+- [ ] **Step 1: Add `hardcoreOn` state + toggle rect storage**
+
+Near the top of `createSelectScene` (with the other scope-local vars like `btnRects`), add:
+
+```js
+  var hardcoreOn = false;
+  var hardcoreToggleRect = null;
+```
+
+- [ ] **Step 2: Render the toggle row + caption beneath difficulty buttons**
+
+Find the end of the difficulty buttons loop in `drawScene` (it pushes to `btnRects.push(...)` and ends with `y += btnH + btnGap;`). Immediately after that loop closes, insert (use `y` from the running layout cursor):
+
+```js
+      // ── Hardcore mode toggle (per-session; not persisted) ─────────────
+      var hcRowH = 36;
+      var hcTrackW = 56, hcTrackH = 28;
+      var hcKnobR = 11;
+      var hcLabelX = (W - btnW) / 2;
+      var hcTrackX = hcLabelX + btnW - hcTrackW;
+      var hcTrackY = y + (hcRowH - hcTrackH) / 2;
+      // Label
+      R.textBold(ctx, '🔥 硬核模式', hcLabelX, y + hcRowH / 2, 16, '#333', 'left', 'middle');
+      // Track + knob
+      R.roundRect(ctx, hcTrackX, hcTrackY, hcTrackW, hcTrackH, hcTrackH / 2,
+        hardcoreOn ? '#FF7043' : '#BDBDBD');
+      var knobX = hardcoreOn
+        ? hcTrackX + hcTrackW - hcKnobR - 4
+        : hcTrackX + hcKnobR + 4;
+      ctx.beginPath();
+      ctx.arc(knobX, hcTrackY + hcTrackH / 2, hcKnobR, 0, Math.PI * 2);
+      ctx.fillStyle = '#fff';
+      ctx.fill();
+      hardcoreToggleRect = { x: hcLabelX, y: y, w: btnW, h: hcRowH };
+      y += hcRowH + 2;
+      // Caption (small grey)
+      R.text(ctx, '关闭提示・换题・券，重开变为清空棋盘',
+        hcLabelX, y + 8, 11, '#888', 'left');
+      y += 18;
+      // ──────────────────────────────────────────────────────────────────
+```
+
+(Style nit — uses existing `R.roundRect`, `R.textBold`, `R.text` helpers already imported by this file.)
+
+- [ ] **Step 3: Add the hit handler in `scene.onTouchEnd`**
+
+Find `scene.onTouchEnd = function (x, y) { ... }` (line ~273). Inside, BEFORE the difficulty `btnRects` loop, add:
+
+```js
+    if (hardcoreToggleRect && R.hitTest(x, y, hardcoreToggleRect)) {
+      hardcoreOn = !hardcoreOn;
+      scene.dirty = true;
+      return;
+    }
+```
+
+- [ ] **Step 4: Pass `hardcoreOn` to the new-game `onSelect(...)` call site**
+
+Find the difficulty `btnRects` loop (line ~375). The terminal `onSelect(d, null, null);` (which Task 3 already widened) becomes:
+
+```js
+        onSelect(d, null, { hardcore: hardcoreOn });
+```
+
+Leave the other 3 `onSelect(..., null)` call sites alone — resume / saved-slot paths read mode from `savedState.mode`.
+
+- [ ] **Step 5: Syntax check**
+
+Run:
+```bash
+node --check minigame/js/selectScene.js
+npm test
+```
+Expected: clean; no test regression (toggle UI has no unit tests — manual verification in Step 6).
+
+- [ ] **Step 6: Manual smoke (record in commit message body if discrepancies)**
+
+Open the project in WeChat 开发者工具 → 选择难度界面：
+- Tap "🔥 硬核模式" → track flips orange, knob slides right. Caption text below visible.
+- Tap a difficulty button → enters game (visual gating proven in Task 5, not yet here — at this stage the game scene still renders normally).
+- Re-open select scene from back button → toggle is OFF (per-session reset is the spec'd behavior).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/selectScene.js
+git commit -m "feat(minigame/selectScene): hardcore mode toggle row (per-session)"
+```
+
+---
+
+## Task 5: gameScene — control row gating (hint / swap hidden, restart → clear)
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/gameScene.js`
+
+The control-row layout currently switches between 4 buttons (default) and 2 buttons (insomnia). Hardcore mode collapses it to 1 button (清空). All three behaviors are unified into a capability-driven layout in this single task because the button positions are mutually dependent.
+
+- [ ] **Step 1: Rewrite the control-row layout block to be capability-driven**
+
+In `calendar-puzzle-miniprogram/minigame/js/gameScene.js`, find the control-row block at lines 648-666 (it starts with the comment `// Control row: 提示 / 重开 / 🎲 / 🎯` and ends with `y += btnH + 10;`). Replace the entire block with:
+
+```js
+    // Control row: 提示 / 重开 / 🎲 / 🎯  — single line.
+    // Layout collapses based on capabilities:
+    //   default:  [💡 提示] [↺ 重开] [🎲 随机] [🎯 选题]      (4 buttons)
+    //   insomnia: [💡 提示] [↺ 重开]                          (2 buttons; no swap)
+    //   hardcore: [🧹 清空]                                    (1 button; replaces 重开)
+    // Hidden during tutorial mode to keep the focus on the banner step.
+    L.hintBtn = null;
+    L.resetBtn = null;
+    L.switchRandomBtn = null;
+    L.switchManualBtn = null;
+    if (!tutorialMode) {
+      var showHint = M.canUseHint(mode);
+      var showSwap = M.canSwapPuzzle(mode) && !isInsomnia;
+      var hardcore = M.isHardcore(mode);
+      var nCtrl = (showHint ? 1 : 0) + 1 /* reset/clear */ + (showSwap ? 2 : 0);
+      var btnH = 36, btnGap = 8;
+      var ctrlBtnW = Math.floor((W - 2 * pad - (nCtrl - 1) * btnGap) / nCtrl);
+      L.ctrlY = y;
+      var idx = 0;
+      if (showHint) {
+        L.hintBtn  = { x: pad + (ctrlBtnW + btnGap) * idx, y: y, w: ctrlBtnW, h: btnH };
+        idx++;
+      }
+      L.resetBtn   = { x: pad + (ctrlBtnW + btnGap) * idx, y: y, w: ctrlBtnW, h: btnH, kind: hardcore ? 'clear' : 'reset' };
+      idx++;
+      if (showSwap) {
+        L.switchRandomBtn = { x: pad + (ctrlBtnW + btnGap) * idx, y: y, w: ctrlBtnW, h: btnH };
+        idx++;
+        L.switchManualBtn = { x: pad + (ctrlBtnW + btnGap) * idx, y: y, w: ctrlBtnW, h: btnH };
+        idx++;
+      }
+      y += btnH + 10;
+    }
+```
+
+(Note the `kind: hardcore ? 'clear' : 'reset'` annotation on `L.resetBtn` — used in Step 2 to choose label, and in Step 3 to choose behavior.)
+
+- [ ] **Step 2: Update the reset-button render call**
+
+Find the reset-button render at line ~958:
+```js
+        R.button(ctx, L.resetBtn.x, L.resetBtn.y, L.resetBtn.w, L.resetBtn.h, '↺ 重开', dropped.length ? NEUTRAL : '#cfcfcf', '#fff', 8);
+```
+
+Change to:
+```js
+        var resetLabel = L.resetBtn.kind === 'clear' ? '🧹 清空' : '↺ 重开';
+        R.button(ctx, L.resetBtn.x, L.resetBtn.y, L.resetBtn.w, L.resetBtn.h, resetLabel, dropped.length ? NEUTRAL : '#cfcfcf', '#fff', 8);
+```
+
+- [ ] **Step 3: Branch the reset-button hit handler — clear-board-keep-timer vs. existing restart**
+
+Find the reset-button hit at line ~2636 (the line that contains `showToast('已重开当前题');`). Read the surrounding handler (likely 5-15 lines above to capture timer reset, dropped→palette move, puzzle.placed clear). Then split the handler:
+
+Replace the existing branch with:
+
+```js
+        if (L.resetBtn.kind === 'clear') {
+          // Hardcore: clear all dropped blocks back to palette; DO NOT reset timer.
+          while (dropped.length) {
+            var blk = dropped.pop();
+            // Reuse the existing dropped→palette move semantics. If the surrounding
+            // handler used helpers (e.g. B.removeFromBoard / B.returnToPalette),
+            // call those instead of mutating dropped/palette directly.
+            palette.push(blk);
+          }
+          // Clear the board's logical placed map. Verify the exact identifier
+          // (often `puzzle.placed` or scene-local `placed`) by grep before edit.
+          if (puzzle && puzzle.placed) {
+            for (var pk in puzzle.placed) { delete puzzle.placed[pk]; }
+          }
+          _tempSlot.markDirty(captureState());
+          showToast('已清空棋盘');
+        } else {
+          // existing restart body (timer reset + dropped→palette + placed clear + toast)
+          // KEEP THE ORIGINAL CODE HERE UNCHANGED — only the branch wrapper is new.
+        }
+```
+
+> Implementation note for the engineer: the actual lines around `gameScene.js:2636` use the project's own conventions for resetting placed/dropped. Read 20 lines of surrounding context first, mirror those exact helpers in the new `'clear'` branch, and keep the `'reset'` branch byte-identical to today's body. The only behavioral difference between branches is: **clear DOES NOT touch `timer` or `timerInterval`**.
+
+- [ ] **Step 4: Syntax check + full test suite**
+
+Run:
+```bash
+node --check minigame/js/gameScene.js
+npm test
+```
+Expected: clean; no regression.
+
+- [ ] **Step 5: Manual smoke (record any deviation in commit body)**
+
+In WeChat 开发者工具:
+- New game with hardcore OFF (any difficulty): control row shows 4 buttons (or 2 for insomnia) as today.
+- New game with hardcore ON (expert): control row shows ONLY "🧹 清空".
+- Place 2-3 blocks → tap 🧹 → blocks return to palette, board empties, **timer keeps running** (don't return to 00:00).
+- New game with hardcore OFF + insomnia: still 2 buttons "💡 提示" + "↺ 重开" (regression check).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/gameScene.js
+git commit -m "feat(minigame/gameScene): hardcore control row — hide hint/swap, replace 重开 with 清空 (keep timer)"
+```
+
+---
+
+## Task 6: gameScene — ☰ pause menu structure (entry button + sheet rendering + dismiss)
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/gameScene.js`
+
+This task wires the chrome only: a top-right `☰` button that toggles a half-screen sheet. The sheet renders an empty container; entries land in Task 7.
+
+- [ ] **Step 1: Add pause-menu state + button rect**
+
+Near the other scene-local flag vars (search for `var tutorialMode` to land near the right cluster), add:
+
+```js
+  var pauseMenuOpen = false;
+```
+
+- [ ] **Step 2: Render the ☰ button in the top bar**
+
+Find the top-bar render block (search for `if (L.backBtn) {` around line 915 — the back-button render). After that block (immediately after its closing `}`), add:
+
+```js
+    // ☰ Pause-menu entry (top-right). Positioned mirror of backBtn relative to safe area.
+    var pmSize = 36;
+    L.pauseBtn = { x: W - pad - pmSize, y: L.backBtn.y, w: pmSize, h: pmSize };
+    ctx.fillStyle = 'rgba(0,0,0,0.06)';
+    ctx.beginPath();
+    ctx.arc(L.pauseBtn.x + pmSize / 2, L.pauseBtn.y + pmSize / 2, pmSize / 2, 0, Math.PI * 2);
+    ctx.fill();
+    R.textBold(ctx, '☰', L.pauseBtn.x + pmSize / 2, L.pauseBtn.y + pmSize / 2 - 1, 22, '#555', 'center', 'middle');
+```
+
+- [ ] **Step 3: Render the empty sheet when `pauseMenuOpen`**
+
+Find a late render point that draws overlays (search for `R.overlay(ctx, W, H)` to find an existing overlay call to model on). Append a new conditional render block near the END of the render function (after all other game UI but before any toasts):
+
+```js
+    if (pauseMenuOpen) {
+      R.overlay(ctx, W, H);
+      var sheetH = Math.floor(H * 0.5);
+      var sheetY = H - sheetH;
+      R.roundRect(ctx, 0, sheetY, W, sheetH, 18, '#fff');
+      R.textBold(ctx, '菜单', W / 2, sheetY + 28, 18, '#333', 'center', 'middle');
+      L.pauseSheet = { x: 0, y: sheetY, w: W, h: sheetH };
+      // Entries rendered in Task 7. This block leaves a blank pane for now.
+    } else {
+      L.pauseSheet = null;
+    }
+```
+
+- [ ] **Step 4: Add hit handlers — ☰ open + tap-outside close**
+
+Find `scene.onTouchEnd = function (x, y) { ... }` (or the equivalent — search for `function (x, y)` and `R.hitTest`). At the TOP of the handler (before any other hit logic), add:
+
+```js
+    // Pause-menu interactions take precedence when open (modal sheet).
+    if (pauseMenuOpen) {
+      // Tap inside the sheet rect: keep open (entries handled in Task 7).
+      if (L.pauseSheet && R.hitTest(x, y, L.pauseSheet)) {
+        return;
+      }
+      // Tap outside (the dimmed overlay) closes the sheet.
+      pauseMenuOpen = false;
+      scene.dirty = true;
+      return;
+    }
+    if (L.pauseBtn && R.hitTest(x, y, L.pauseBtn)) {
+      pauseMenuOpen = true;
+      scene.dirty = true;
+      return;
+    }
+```
+
+- [ ] **Step 5: Syntax check + tests**
+
+Run:
+```bash
+node --check minigame/js/gameScene.js
+npm test
+```
+Expected: clean; no regression.
+
+- [ ] **Step 6: Manual smoke**
+
+In WeChat 开发者工具:
+- New game (any mode): top-right shows ☰ button next to (mirror of) the existing back arrow.
+- Tap ☰ → bottom half overlay slides up showing a white sheet with "菜单" header.
+- Tap inside the sheet (on the blank area) → nothing happens.
+- Tap outside the sheet (the dimmed top area) → sheet closes.
+- Tap ☰ again → reopens. Back arrow ↩ still works normally (goes to selectScene).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/gameScene.js
+git commit -m "feat(minigame/gameScene): ☰ pause-menu entry + half-screen sheet shell"
+```
+
+---
+
+## Task 7: gameScene — pause menu 3 entries + 放弃硬核 downgrade flow
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/gameScene.js`
+
+Entries (top-to-bottom inside the sheet):
+1. **🔥 放弃硬核** — only when `M.isHardcore(scene.mode)`; opens a two-step confirm before downgrading.
+2. **🏠 返回首页** — calls `callbacks.onBack()` (the same callback used by `L.backBtn`).
+3. **Title block** — read-only: `<dateStr> · <difficulty label> · 🔥 硬核` (drop the suffix when not hardcore).
+
+- [ ] **Step 1: Add confirm-dialog state**
+
+Near `pauseMenuOpen`, add:
+
+```js
+  var abandonConfirmOpen = false;
+```
+
+- [ ] **Step 2: Render the 3 entries inside the sheet block (from Task 6)**
+
+Inside the `if (pauseMenuOpen) { ... }` block added in Task 6 (right after the `'菜单'` header text), replace the `// Entries rendered in Task 7.` comment with:
+
+```js
+      var rowH = 56, rowGap = 8;
+      var rowX = 16, rowY = sheetY + 60, rowW = W - 32;
+
+      L.pauseRowAbandon = null;
+      if (M.isHardcore(mode)) {
+        R.roundRect(ctx, rowX, rowY, rowW, rowH, 12, '#FFF3E0');
+        R.textBold(ctx, '🔥 放弃硬核', rowX + 16, rowY + rowH / 2, 16, '#E64A19', 'left', 'middle');
+        L.pauseRowAbandon = { x: rowX, y: rowY, w: rowW, h: rowH };
+        rowY += rowH + rowGap;
+      }
+
+      R.roundRect(ctx, rowX, rowY, rowW, rowH, 12, '#F5F5F5');
+      R.textBold(ctx, '🏠 返回首页', rowX + 16, rowY + rowH / 2, 16, '#333', 'left', 'middle');
+      L.pauseRowBack = { x: rowX, y: rowY, w: rowW, h: rowH };
+      rowY += rowH + rowGap;
+
+      // Read-only title block
+      var difficultyLabel = (PG && PG.DIFFICULTY_CONFIG && PG.DIFFICULTY_CONFIG[difficulty] && PG.DIFFICULTY_CONFIG[difficulty].label) || difficulty;
+      var titleStr = puzzle.dateStr + ' · ' + difficultyLabel + (M.isHardcore(mode) ? ' · 🔥 硬核' : '');
+      R.text(ctx, titleStr, rowX, rowY + 8, 13, '#666', 'left');
+```
+
+> Note: `PG` is the puzzleGenerator module (search `require('./puzzleGenerator')` near the top of gameScene.js; if the local var has a different name, adjust). If `PG.DIFFICULTY_CONFIG` is not in scope at this file, fall back to the raw `difficulty` string.
+
+- [ ] **Step 3: Render the abandon-confirm dialog (on top of the sheet) when `abandonConfirmOpen`**
+
+After the `if (pauseMenuOpen) { ... }` block, add a separate overlay:
+
+```js
+    if (abandonConfirmOpen) {
+      R.overlay(ctx, W, H);
+      var dW = W * 0.84, dH = 200;
+      var dx = (W - dW) / 2, dy = (H - dH) / 2;
+      R.roundRect(ctx, dx, dy, dW, dH, 14, '#fff');
+      R.textBold(ctx, '放弃硬核?', dx + dW / 2, dy + 32, 18, '#333', 'center', 'middle');
+      R.text(ctx, '放弃后本局不再计入今日硬核通关，确定?', dx + dW / 2, dy + 70, 13, '#666', 'center');
+      var cBtnW = (dW - 48) / 2, cBtnH = 44;
+      L.abandonCancelBtn  = { x: dx + 16,                  y: dy + dH - 16 - cBtnH, w: cBtnW, h: cBtnH };
+      L.abandonConfirmBtn = { x: dx + 16 + cBtnW + 16,     y: dy + dH - 16 - cBtnH, w: cBtnW, h: cBtnH };
+      R.button(ctx, L.abandonCancelBtn.x,  L.abandonCancelBtn.y,  cBtnW, cBtnH, '取消',     '#eee',    '#333', 8);
+      R.button(ctx, L.abandonConfirmBtn.x, L.abandonConfirmBtn.y, cBtnW, cBtnH, '确定放弃', '#E64A19', '#fff', 8);
+    } else {
+      L.abandonCancelBtn = null;
+      L.abandonConfirmBtn = null;
+    }
+```
+
+- [ ] **Step 4: Wire hit handlers — entries + confirm dialog**
+
+In `scene.onTouchEnd`, find the block added in Task 6 (the `if (pauseMenuOpen) { ... }` block). Replace its body with the full handler:
+
+```js
+    if (abandonConfirmOpen) {
+      if (L.abandonCancelBtn && R.hitTest(x, y, L.abandonCancelBtn)) {
+        abandonConfirmOpen = false;
+        scene.dirty = true;
+        return;
+      }
+      if (L.abandonConfirmBtn && R.hitTest(x, y, L.abandonConfirmBtn)) {
+        // Downgrade: rebuild mode without hardcore, repaint, persist.
+        mode = M.createMode({ hardcore: false });
+        scene.mode = mode;
+        abandonConfirmOpen = false;
+        pauseMenuOpen = false;
+        _tempSlot.markDirty(captureState());
+        showToast('已切回普通模式');
+        scene.dirty = true;
+        return;
+      }
+      return; // swallow taps elsewhere while confirm is open
+    }
+    if (pauseMenuOpen) {
+      if (L.pauseRowAbandon && R.hitTest(x, y, L.pauseRowAbandon)) {
+        abandonConfirmOpen = true;
+        scene.dirty = true;
+        return;
+      }
+      if (L.pauseRowBack && R.hitTest(x, y, L.pauseRowBack)) {
+        pauseMenuOpen = false;
+        // Same callback path as the top-left back arrow uses.
+        if (callbacks && callbacks.onBack) callbacks.onBack();
+        return;
+      }
+      if (L.pauseSheet && R.hitTest(x, y, L.pauseSheet)) {
+        return; // tap on blank sheet area = no-op
+      }
+      pauseMenuOpen = false;
+      scene.dirty = true;
+      return;
+    }
+    if (L.pauseBtn && R.hitTest(x, y, L.pauseBtn)) {
+      pauseMenuOpen = true;
+      scene.dirty = true;
+      return;
+    }
+```
+
+(This entire block replaces the slimmer version from Task 6.)
+
+- [ ] **Step 5: Syntax check + tests**
+
+Run:
+```bash
+node --check minigame/js/gameScene.js
+npm test
+```
+Expected: clean; no regression.
+
+- [ ] **Step 6: Manual smoke**
+
+In WeChat 开发者工具:
+- Start a **hardcore** expert game → ☰ → sheet shows: `🔥 放弃硬核` row (orange), `🏠 返回首页` row (grey), title `YYYY-MM-DD · 加班赶报告 · 🔥 硬核`.
+- Tap 🔥 放弃硬核 → confirm dialog appears with `取消` / `确定放弃` buttons.
+- Tap 取消 → dialog closes, sheet still open, row still there.
+- Tap 🔥 放弃硬核 again → confirm dialog → 确定放弃 → toast `已切回普通模式`, sheet closes, control row now shows 4 buttons (`💡 提示 / ↺ 重开 / 🎲 随机 / 🎯 选题`), open ☰ again → no `放弃硬核` row, title shows `... · 加班赶报告` (no 🔥 suffix).
+- Start a **non-hardcore** game → ☰ → sheet shows only `🏠 返回首页` + title (no `放弃硬核` row).
+- Tap 🏠 返回首页 → returns to selectScene (same as ↩).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/gameScene.js
+git commit -m "feat(minigame/gameScene): pause-menu entries + 放弃硬核 downgrade flow"
+```
+
+---
+
+## Task 8: gameScene — `markHardcoreCleared` on win + "🔥 硬核通关" label in win modal
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/gameScene.js`
+
+- [ ] **Step 1: Call `markHardcoreCleared` on hardcore wins; carry the boolean into `winStats`**
+
+In `calendar-puzzle-miniprogram/minigame/js/gameScene.js`, find the puzzle.success block at line ~415-430 (the block that sets `var insomniaUnique = null; if (isInsomnia) { ... }` and then builds `winStats = { ... }`). Modify it as follows:
+
+After the existing `if (isInsomnia) { ... }` block, before `winStats = {`, add:
+
+```js
+        var hardcoreClear = false;
+        if (M.isHardcore(mode)) {
+          progress.markHardcoreCleared(puzzle.dateStr, difficulty);
+          hardcoreClear = true;
+        }
+```
+
+In the `winStats = { ... }` literal, add one new key:
+
+```js
+          hardcore: hardcoreClear,
+```
+
+Resulting block:
+
+```js
+        var insomniaUnique = null;
+        if (isInsomnia) {
+          insomniaUnique = progress.markUniqueInsomnia(puzzle.dateStr, buildBoardKey());
+        }
+        var hardcoreClear = false;
+        if (M.isHardcore(mode)) {
+          progress.markHardcoreCleared(puzzle.dateStr, difficulty);
+          hardcoreClear = true;
+        }
+        winStats = {
+          time: timer,
+          isNewPB: pb.isNew,
+          prevPB: pb.prev,
+          todayDone: progress.countCompletedForDate(puzzle.dateStr),
+          insomniaUnique: insomniaUnique,
+          hardcore: hardcoreClear,
+        };
+```
+
+Note: `hardcoreClear` reflects "this clear was a hardcore clear", not `markHardcoreCleared`'s return value — so the label appears even on a same-day repeat clear.
+
+- [ ] **Step 2: Render "🔥 硬核通关" label in the win modal**
+
+Find the win-modal text rendering block. Use the existing `'🎉 恭喜通关'` string as an anchor — search:
+```bash
+grep -n "恭喜通关\|isNewPB\|winStats\." minigame/js/gameScene.js | head -30
+```
+
+In the modal's text-render section (where `winStats.time`, `winStats.isNewPB`, `winStats.todayDone` are drawn), add a conditional line **before** the time/PB line so the badge sits at the top:
+
+```js
+        if (winStats.hardcore) {
+          R.textBold(ctx, '🔥 硬核通关', winModalCenterX, winModalCursorY, 16, '#E64A19', 'center', 'middle');
+          winModalCursorY += 24;
+        }
+```
+
+> Variable names `winModalCenterX` / `winModalCursorY` are placeholders for whatever local coordinates the existing render block uses. Read 20 lines around `winStats.time` to find the actual identifiers (often `mx`, `my`, `cx`, `cy`, etc.), and substitute. The conditional + bumping logic is the contract.
+
+- [ ] **Step 3: Syntax check + tests**
+
+Run:
+```bash
+node --check minigame/js/gameScene.js
+npm test
+```
+Expected: clean; no regression.
+
+- [ ] **Step 4: Manual smoke**
+
+In WeChat 开发者工具:
+- Start a hardcore easy game (`digCount: 3`, fastest to win). Place blocks to win.
+- Win modal shows **"🔥 硬核通关"** at the top of the stats block.
+- Open the WeChat 开发者工具 console → run `wx.getStorageSync('calendarPuzzleHardcoreDays')` → JSON includes `{ "<today>": { "easy": true } }`.
+- Start a NON-hardcore easy game → win → modal shows NO `🔥 硬核通关` line; storage unchanged for this difficulty.
+- Start a hardcore expert game → mid-game ☰ → 放弃硬核 → 确定放弃 → finish the game → win modal has NO `🔥 硬核通关` line; storage NOT updated for `expert`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/gameScene.js
+git commit -m "feat(minigame/gameScene): mark hardcore clear on win + 🔥 硬核通关 modal label"
+```
+
+---
+
+## Task 9: CHANGELOG 0.7.0
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/CHANGELOG.md`
+
+- [ ] **Step 1: Prepend the 0.7.0 entry at the top of the changelog (above the most recent 0.6.0 block)**
+
+Insert at the top of `calendar-puzzle-miniprogram/minigame/CHANGELOG.md`:
+
+```markdown
+## [0.7.0] — 2026-05-27
+
+### Added
+- 硬核模式开关（`selectScene` 难度按钮下方一行，🔥 toggle，per-session 不持久）。开启后任何底层难度均进入硬核局。
+- 暂停菜单 ☰（顶栏右上）半屏 sheet — MVP 三条：`🔥 放弃硬核`（仅硬核局可见，单向降级）、`🏠 返回首页`、当前题面只读信息。
+- 通关结算页"🔥 硬核通关"标签（仅硬核局展示）。
+- `progress.hardcoreDays` 持久化每日每难度的硬核通关记录（storage key `calendarPuzzleHardcoreDays`）。
+- `mode.js` 模块：mode 对象 + capability helpers（`canUseHint` / `canSwapPuzzle` / `canRestart` / `canClearBoard`），未来扩展模式的容器。
+
+### Changed
+- 硬核局控制行折叠为 1 个按钮 "🧹 清空"（替代 "↺ 重开"），**清空时计时器不重置**；提示、🎲 随机、🎯 选题在硬核局不渲染。
+- 存档 slot payload 新增 `mode: { hardcore: bool }` 字段；老存档无此字段自动视作非硬核（向后兼容，无需迁移）。
+- `createGameScene(...)` 入参增加第 7 位 `modeOpts`；`selectScene` `onSelect(difficulty, savedState, modeOpts)`；`main.js` 三层透传。
+
+### Tests
+- 新 `tests/mode.test.js`：mode 模块全分支（7 用例）。
+- 新 `tests/progress.hardcore.test.js`：hardcoreDays 持久化 + 幂等 + 跨难度并存 + storage round-trip（5 用例）。
+- `tests/slotStore.test.js` +2：`mode` 字段 round-trip + 老 payload 无字段回读。
+
+### Manual verification required (真机 / 微信开发者工具)
+- 见 `docs/superpowers/specs/2026-05-27-hardcore-mode-design.md` §6.2 (1-8)。
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/CHANGELOG.md
+git commit -m "docs(minigame): CHANGELOG 0.7.0 — hardcore mode"
+```
+
+---
+
+## Final verification
+
+After Task 9 is committed, run:
+
+```bash
+cd calendar-puzzle-miniprogram
+npm test
+```
+
+Expected: all prior tests pass + 14 new tests (mode: 7, progress.hardcore: 5, slotStore: 2). Record the total in the eventual PR description.
+
+Then run the manual smoke matrix in `docs/superpowers/specs/2026-05-27-hardcore-mode-design.md` §6.2 (paths 1-8) on real device or WeChat 开发者工具. Record evidence (screenshot paths + console outputs) before flipping the `feature_list.json` entry to `passing`.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+
+| Spec section | Covered by |
+|---|---|
+| §2.1 Mode 抽象 | Task 1 |
+| §2.2 selectScene 入口 UI | Task 4 |
+| §2.3 gameScene 内 gating (4 处) | Task 5 (#1, #2, #3, #4 unified — `nCtrl` capability-driven) |
+| §2.4 暂停菜单 (MVP 3 条) | Task 6 (chrome) + Task 7 (entries + 放弃硬核 flow) |
+| §2.5 通关判定 & 进度记录 | Task 2 (progress functions) + Task 8 (call site + modal label) |
+| §3 数据流 | Tasks 3, 5, 7, 8 in aggregate |
+| §4.1 存档 schema | Task 3 (captureState + slotStore tests) |
+| §4.2 progress 持久层 | Task 2 |
+| §5 错误处理 & 兼容性 | Old-save default (Task 3 mode resolution); slotStore legacy test (Task 3 step 1) |
+| §6.1 单元测试 | Tasks 1, 2, 3 |
+| §6.2 手测路径 (1-8) | Final verification section + per-task smoke notes |
+| §7 已知风险 | Acknowledged in tasks (☰ placement uses `pad` not safe-area collision; assumes backBtn coexists) |
+| §9 文件清单 | All listed files appear in this plan |
+
+**Placeholder scan:** No `TBD`/`TODO`/`fill-in`. Two locations use the explicit phrasing `> Implementation note for the engineer:` to flag a context-dependent identifier (variable name in the win modal in Task 8 Step 2; `puzzle.placed` vs scene-local `placed` in Task 5 Step 3). These are *findable in 30 seconds* with a grep and the surrounding intent is fully specified.
+
+**Type / API consistency:**
+- `M.createMode(opts)` defined Task 1, used Tasks 3, 7, 8.
+- `M.isHardcore(mode)` / `M.canUseHint(mode)` / `M.canSwapPuzzle(mode)` / `M.canRestart(mode)` defined Task 1, used Tasks 5, 7, 8.
+- `progress.markHardcoreCleared(dateStr, difficulty)` / `progress.hasHardcoreCleared(dateStr, difficulty)` defined Task 2, used Task 8.
+- Save payload `mode: {hardcore: bool}` shape consistent across Task 3 (captureState), Task 3 (slotStore tests), Task 4 (selectScene → onSelect), Task 5 (`mode` local in gameScene), Task 7 (downgrade rewrites it).
+- Scene mode access uses `mode` (the local var) at the call site, mirrored on `scene.mode` for external readers (used by `main.js` `onSwitchPuzzle` callback in Task 3 Step 5d).

--- a/docs/superpowers/plans/2026-05-27-medium-hint-mismatch-dialog.md
+++ b/docs/superpowers/plans/2026-05-27-medium-hint-mismatch-dialog.md
@@ -1,0 +1,975 @@
+# Medium-Hint Mismatch Dialog — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pop a modal when the player drops a block that contradicts an active medium hint (wrong block on a hinted cell, OR right block at wrong location), with a one-tap take-back-and-reselect, an opt-out for the puzzle, and an explicit close that lets the next mismatch re-fire.
+
+**Architecture:** Pure-function detection in `hint.js` (`findMediumMismatch` + `setMediumMismatchIgnored`), suppression flag piggybacking on `hintState.mediumMismatchIgnored` (round-trips through the existing `restoreHintState` path), modal UI in `gameScene.js` mirroring the `staminaConfirm` modal pattern.
+
+**Tech Stack:** Plain JS (no TypeScript), `node --test` for hint.js tests (no harness for gameScene), WeChat mini-game Canvas API via `R` (`./render`) helpers, hint state via `Hint` (`./hint`).
+
+**Spec:** `docs/superpowers/specs/2026-05-27-medium-hint-mismatch-dialog-design.md`
+
+---
+
+## File Structure
+
+- `calendar-puzzle-miniprogram/minigame/js/hint.js` — three additive changes: one new field in `createHintState`, one new round-trip line in `restoreHintState`, two new exported functions (`findMediumMismatch`, `setMediumMismatchIgnored`). Pure functions only; no `wx.*` calls.
+- `calendar-puzzle-miniprogram/minigame/js/gameScene.js` — three additive changes: two new module-scope `var`s for modal state, a detection call at the end of `placeBlock`, a render block after `staminaConfirm`, and a tap handler near the existing `slotModal` handler. No refactor of existing flow.
+- `calendar-puzzle-miniprogram/tests/hint.test.js` — 8 new `test(...)` cases covering both helpers and the `restoreHintState` field round-trip.
+- `calendar-puzzle-miniprogram/minigame/CHANGELOG.md` — one new `[0.6.0]` entry summarising the feature and manual-test path.
+
+---
+
+## Task 1: hint.js — add `mediumMismatchIgnored` field + restore round-trip
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/hint.js:7-17` (`createHintState`)
+- Modify: `calendar-puzzle-miniprogram/minigame/js/hint.js:65-73` (`restoreHintState` return object)
+- Test: `calendar-puzzle-miniprogram/tests/hint.test.js`
+
+- [ ] **Step 1: Write failing test for `createHintState` default**
+
+Append to `calendar-puzzle-miniprogram/tests/hint.test.js`:
+
+```js
+test('createHintState initialises mediumMismatchIgnored to false', function () {
+  var s = H.createHintState('p-mm-1');
+  assert.strictEqual(s.mediumMismatchIgnored, false);
+});
+```
+
+- [ ] **Step 2: Run the new test — verify it fails**
+
+Run: `cd calendar-puzzle-miniprogram && node --test tests/hint.test.js 2>&1 | grep -E "mediumMismatchIgnored|fail" | head -5`
+
+Expected: a line like `not ok` or `Expected: false / Actual: undefined`. The field doesn't exist yet.
+
+- [ ] **Step 3: Add the field in `createHintState`**
+
+Edit `calendar-puzzle-miniprogram/minigame/js/hint.js`.
+
+`old_string`:
+
+```js
+function createHintState(puzzleId) {
+  return {
+    puzzleId: puzzleId,
+    weakLocked: {},
+    mediumLocked: {},
+    strongLocked: {},
+    usedWeak: 0,
+    usedMedium: 0,
+    usedStrong: 0,
+  };
+}
+```
+
+`new_string`:
+
+```js
+function createHintState(puzzleId) {
+  return {
+    puzzleId: puzzleId,
+    weakLocked: {},
+    mediumLocked: {},
+    strongLocked: {},
+    usedWeak: 0,
+    usedMedium: 0,
+    usedStrong: 0,
+    mediumMismatchIgnored: false,
+  };
+}
+```
+
+- [ ] **Step 4: Re-run the new test — verify it passes**
+
+Run: `cd calendar-puzzle-miniprogram && node --test tests/hint.test.js 2>&1 | tail -10`
+
+Expected: tests pass, no `not ok` lines.
+
+- [ ] **Step 5: Write failing tests for `restoreHintState` round-trip**
+
+Append to `calendar-puzzle-miniprogram/tests/hint.test.js`:
+
+```js
+test('restoreHintState defaults mediumMismatchIgnored to false when absent', function () {
+  var saved = { puzzleId: 'p-mm-rt-1', weakLocked: {}, mediumLocked: {}, strongLocked: {}, usedWeak: 0, usedMedium: 0, usedStrong: 0 };
+  var s = H.restoreHintState(saved, 'p-mm-rt-1');
+  assert.strictEqual(s.mediumMismatchIgnored, false);
+});
+
+test('restoreHintState round-trips mediumMismatchIgnored: true', function () {
+  var saved = { puzzleId: 'p-mm-rt-2', weakLocked: {}, mediumLocked: {}, strongLocked: {}, usedWeak: 0, usedMedium: 0, usedStrong: 0, mediumMismatchIgnored: true };
+  var s = H.restoreHintState(saved, 'p-mm-rt-2');
+  assert.strictEqual(s.mediumMismatchIgnored, true);
+});
+```
+
+- [ ] **Step 6: Run — confirm only the round-trip-true test fails**
+
+Run: `cd calendar-puzzle-miniprogram && node --test tests/hint.test.js 2>&1 | grep "not ok" | head -5`
+
+Expected: one failure mentioning `round-trips mediumMismatchIgnored: true` (the default-false test passes by accident because `saved.mediumMismatchIgnored === true` is `false`, which assigns nothing and the returned object lacks the field — so `s.mediumMismatchIgnored` is `undefined`, which is `!== false`. So actually BOTH may fail. Either way, at least one failure must mention `mediumMismatchIgnored`.)
+
+If neither fails, stop and recheck — the test file probably wasn't saved.
+
+- [ ] **Step 7: Add the round-trip line in `restoreHintState`**
+
+Edit `calendar-puzzle-miniprogram/minigame/js/hint.js`.
+
+`old_string`:
+
+```js
+  return {
+    puzzleId: puzzleId,
+    weakLocked: _cloneBoolMap(saved.weakLocked),
+    mediumLocked: _cloneCellsMap(saved.mediumLocked),
+    strongLocked: _cloneStrongMap(saved.strongLocked),
+    usedWeak: typeof saved.usedWeak === 'number' ? saved.usedWeak : 0,
+    usedMedium: typeof saved.usedMedium === 'number' ? saved.usedMedium : 0,
+    usedStrong: typeof saved.usedStrong === 'number' ? saved.usedStrong : 0,
+  };
+}
+```
+
+`new_string`:
+
+```js
+  return {
+    puzzleId: puzzleId,
+    weakLocked: _cloneBoolMap(saved.weakLocked),
+    mediumLocked: _cloneCellsMap(saved.mediumLocked),
+    strongLocked: _cloneStrongMap(saved.strongLocked),
+    usedWeak: typeof saved.usedWeak === 'number' ? saved.usedWeak : 0,
+    usedMedium: typeof saved.usedMedium === 'number' ? saved.usedMedium : 0,
+    usedStrong: typeof saved.usedStrong === 'number' ? saved.usedStrong : 0,
+    mediumMismatchIgnored: saved.mediumMismatchIgnored === true,
+  };
+}
+```
+
+- [ ] **Step 8: Re-run all hint tests — confirm green**
+
+Run: `cd calendar-puzzle-miniprogram && node --test tests/hint.test.js 2>&1 | tail -10`
+
+Expected: all tests pass, including the three new ones added in this task.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/hint.js calendar-puzzle-miniprogram/tests/hint.test.js
+git commit -m "feat(minigame/hint): mediumMismatchIgnored field + restoreHintState round-trip"
+```
+
+---
+
+## Task 2: hint.js — `findMediumMismatch` pure function + tests
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/hint.js` — add function before `module.exports` (around line 330), add to exports
+- Test: `calendar-puzzle-miniprogram/tests/hint.test.js`
+
+- [ ] **Step 1: Write five failing tests covering all branches**
+
+Append to `calendar-puzzle-miniprogram/tests/hint.test.js`:
+
+```js
+function _cellEq(a, b) { return a.x === b.x && a.y === b.y; }
+function _cellsContain(set, c) { for (var i = 0; i < set.length; i++) if (_cellEq(set[i], c)) return true; return false; }
+function _isSubset(sub, sup) { for (var i = 0; i < sub.length; i++) if (!_cellsContain(sup, sub[i])) return false; return true; }
+
+test('findMediumMismatch returns null when mediumLocked is empty', function () {
+  var s = H.createHintState('p-fm-1');
+  var cells = [{ x: 0, y: 0 }, { x: 1, y: 0 }];
+  assert.strictEqual(H.findMediumMismatch(s, 'A-block', cells), null);
+});
+
+test('findMediumMismatch returns null when block covers all its own hint cells', function () {
+  var s = H.createHintState('p-fm-2');
+  s.mediumLocked['A-block'] = [{ x: 2, y: 3 }, { x: 3, y: 3 }];
+  var coversAll = [{ x: 2, y: 3 }, { x: 3, y: 3 }, { x: 4, y: 3 }];
+  assert.strictEqual(H.findMediumMismatch(s, 'A-block', coversAll), null);
+});
+
+test('findMediumMismatch returns right-block-wrong-loc when block misses any own hint cell', function () {
+  var s = H.createHintState('p-fm-3');
+  s.mediumLocked['A-block'] = [{ x: 2, y: 3 }, { x: 3, y: 3 }];
+  var missesOne = [{ x: 2, y: 3 }, { x: 2, y: 4 }];
+  var r = H.findMediumMismatch(s, 'A-block', missesOne);
+  assert.deepStrictEqual(r, { kind: 'right-block-wrong-loc', blockId: 'A-block' });
+});
+
+test('findMediumMismatch returns wrong-block-on-hint when foreign block covers another hint cell', function () {
+  var s = H.createHintState('p-fm-4');
+  s.mediumLocked['A-block'] = [{ x: 2, y: 3 }];
+  var foreign = [{ x: 2, y: 3 }, { x: 3, y: 3 }];
+  var r = H.findMediumMismatch(s, 'B-block', foreign);
+  assert.deepStrictEqual(r, { kind: 'wrong-block-on-hint', placedBlockId: 'B-block', hintedBlockId: 'A-block' });
+});
+
+test('findMediumMismatch prioritises right-block-wrong-loc over wrong-block-on-hint', function () {
+  var s = H.createHintState('p-fm-5');
+  s.mediumLocked['A-block'] = [{ x: 2, y: 3 }, { x: 3, y: 3 }];
+  s.mediumLocked['B-block'] = [{ x: 5, y: 5 }];
+  // A-block is the placed block, misses one of its own cells (3,3), AND covers B-block's (5,5)
+  var weird = [{ x: 2, y: 3 }, { x: 5, y: 5 }];
+  var r = H.findMediumMismatch(s, 'A-block', weird);
+  assert.deepStrictEqual(r, { kind: 'right-block-wrong-loc', blockId: 'A-block' });
+});
+```
+
+- [ ] **Step 2: Run — confirm all five fail**
+
+Run: `cd calendar-puzzle-miniprogram && node --test tests/hint.test.js 2>&1 | grep "not ok" | head -10`
+
+Expected: at least 5 `not ok` lines, all referencing `findMediumMismatch`.
+
+- [ ] **Step 3: Implement `findMediumMismatch`**
+
+Edit `calendar-puzzle-miniprogram/minigame/js/hint.js`.
+
+`old_string`:
+
+```js
+module.exports = {
+  CAPS: CAPS,
+```
+
+`new_string`:
+
+```js
+// Returns the first medium-hint violation caused by placing `blockId` at the
+// cells in `blockCells`. Priority: a block that has its own active medium
+// hint and fails to cover all of its hint cells wins over a block (own or
+// foreign) that happens to land on another block's hint cells. Pure function.
+//   state: hintState
+//   blockId: string — the block that was just dropped
+//   blockCells: Array<{x, y}> — the cells `blockId` occupies after the drop
+// Returns:
+//   null — no violation
+//   { kind: 'right-block-wrong-loc', blockId } — own hint not fully covered
+//   { kind: 'wrong-block-on-hint', placedBlockId, hintedBlockId } — covers
+//     another block's hint cell
+function findMediumMismatch(state, blockId, blockCells) {
+  if (!state || !state.mediumLocked) return null;
+  var ownHint = state.mediumLocked[blockId];
+  if (ownHint && ownHint.length > 0) {
+    // Scenario B — does blockCells contain every hinted cell?
+    var coversAll = true;
+    for (var i = 0; i < ownHint.length; i++) {
+      var hc = ownHint[i];
+      var found = false;
+      for (var j = 0; j < blockCells.length; j++) {
+        if (blockCells[j].x === hc.x && blockCells[j].y === hc.y) { found = true; break; }
+      }
+      if (!found) { coversAll = false; break; }
+    }
+    if (!coversAll) return { kind: 'right-block-wrong-loc', blockId: blockId };
+  }
+  // Scenario A — does blockCells intersect any other block's mediumLocked cells?
+  for (var hintedId in state.mediumLocked) {
+    if (!Object.prototype.hasOwnProperty.call(state.mediumLocked, hintedId)) continue;
+    if (hintedId === blockId) continue;
+    var cells = state.mediumLocked[hintedId];
+    if (!cells || cells.length === 0) continue;
+    for (var ci = 0; ci < cells.length; ci++) {
+      for (var bi = 0; bi < blockCells.length; bi++) {
+        if (blockCells[bi].x === cells[ci].x && blockCells[bi].y === cells[ci].y) {
+          return { kind: 'wrong-block-on-hint', placedBlockId: blockId, hintedBlockId: hintedId };
+        }
+      }
+    }
+  }
+  return null;
+}
+
+module.exports = {
+  CAPS: CAPS,
+```
+
+- [ ] **Step 4: Add `findMediumMismatch` to exports**
+
+Edit `calendar-puzzle-miniprogram/minigame/js/hint.js`.
+
+`old_string`:
+
+```js
+  isMediumExhausted: isMediumExhausted,
+  applyWeak: applyWeak,
+```
+
+`new_string`:
+
+```js
+  isMediumExhausted: isMediumExhausted,
+  findMediumMismatch: findMediumMismatch,
+  applyWeak: applyWeak,
+```
+
+- [ ] **Step 5: Run the new five tests — confirm green**
+
+Run: `cd calendar-puzzle-miniprogram && node --test tests/hint.test.js 2>&1 | tail -10`
+
+Expected: full suite passes, including the five `findMediumMismatch` tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/hint.js calendar-puzzle-miniprogram/tests/hint.test.js
+git commit -m "feat(minigame/hint): findMediumMismatch pure-function detector"
+```
+
+---
+
+## Task 3: hint.js — `setMediumMismatchIgnored` + immutability test
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/hint.js` — add function near `findMediumMismatch`, add to exports
+- Test: `calendar-puzzle-miniprogram/tests/hint.test.js`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `calendar-puzzle-miniprogram/tests/hint.test.js`:
+
+```js
+test('setMediumMismatchIgnored returns new state with flag true, original untouched', function () {
+  var s = H.createHintState('p-set-1');
+  var s2 = H.setMediumMismatchIgnored(s);
+  assert.strictEqual(s2.mediumMismatchIgnored, true);
+  assert.strictEqual(s.mediumMismatchIgnored, false, 'original state must not be mutated');
+  assert.notStrictEqual(s2, s, 'must return a new object reference');
+});
+```
+
+- [ ] **Step 2: Run — confirm it fails**
+
+Run: `cd calendar-puzzle-miniprogram && node --test tests/hint.test.js 2>&1 | grep "not ok" | head -3`
+
+Expected: one `not ok` referencing `setMediumMismatchIgnored`.
+
+- [ ] **Step 3: Add the function (place it directly below `findMediumMismatch`)**
+
+Edit `calendar-puzzle-miniprogram/minigame/js/hint.js`.
+
+`old_string`:
+
+```js
+  return null;
+}
+
+module.exports = {
+```
+
+`new_string`:
+
+```js
+  return null;
+}
+
+// Immutable setter for the per-puzzle "stop bugging me about medium mismatches"
+// flag. Caller writes the returned state back into hintState; the field
+// survives save/reload via restoreHintState.
+function setMediumMismatchIgnored(state) {
+  return Object.assign({}, state, { mediumMismatchIgnored: true });
+}
+
+module.exports = {
+```
+
+- [ ] **Step 4: Add to exports**
+
+Edit `calendar-puzzle-miniprogram/minigame/js/hint.js`.
+
+`old_string`:
+
+```js
+  findMediumMismatch: findMediumMismatch,
+  applyWeak: applyWeak,
+```
+
+`new_string`:
+
+```js
+  findMediumMismatch: findMediumMismatch,
+  setMediumMismatchIgnored: setMediumMismatchIgnored,
+  applyWeak: applyWeak,
+```
+
+- [ ] **Step 5: Run — confirm green**
+
+Run: `cd calendar-puzzle-miniprogram && node --test tests/hint.test.js 2>&1 | tail -10`
+
+Expected: full suite passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/hint.js calendar-puzzle-miniprogram/tests/hint.test.js
+git commit -m "feat(minigame/hint): setMediumMismatchIgnored immutable setter"
+```
+
+---
+
+## Task 4: gameScene — modal state vars + trigger in `placeBlock`
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/gameScene.js:118-120` (declarations region)
+- Modify: `calendar-puzzle-miniprogram/minigame/js/gameScene.js:440-465` (`placeBlock` function)
+
+- [ ] **Step 1: Add the two new module-scope state vars near `slotModal`**
+
+Run: `sed -n '117,121p' calendar-puzzle-miniprogram/minigame/js/gameScene.js`
+
+Expected output (must match before editing):
+
+```js
+  // ---- Save-slot modal state ----
+  var slotModal = null;               // null | 'save-picker' | 'overwrite-warning'
+  var slotPickerSelectedIdx = 0;      // 0..2
+  var slotPickerLayoutCache = null;   // cached layout for the active modal
+```
+
+Edit `calendar-puzzle-miniprogram/minigame/js/gameScene.js`.
+
+`old_string`:
+
+```js
+  // ---- Save-slot modal state ----
+  var slotModal = null;               // null | 'save-picker' | 'overwrite-warning'
+  var slotPickerSelectedIdx = 0;      // 0..2
+  var slotPickerLayoutCache = null;   // cached layout for the active modal
+```
+
+`new_string`:
+
+```js
+  // ---- Save-slot modal state ----
+  var slotModal = null;               // null | 'save-picker' | 'overwrite-warning'
+  var slotPickerSelectedIdx = 0;      // 0..2
+  var slotPickerLayoutCache = null;   // cached layout for the active modal
+
+  // ---- Medium-hint mismatch modal state ----
+  // null when no dialog open. Set by placeBlock() to one of:
+  //   { kind: 'right-block-wrong-loc', blockId }
+  //   { kind: 'wrong-block-on-hint', placedBlockId, hintedBlockId }
+  var mediumMismatchModal = null;
+  var mediumMismatchLayoutCache = null;
+```
+
+- [ ] **Step 2: Confirm `placeBlock` state before editing**
+
+Run: `sed -n '440,465p' calendar-puzzle-miniprogram/minigame/js/gameScene.js`
+
+Expected output (must match before editing):
+
+```js
+  function placeBlock(block, cx, cy, fromX, fromY) {
+    var nb = B.cloneBlock(block);
+    nb.x = cx; nb.y = cy;
+    dropped.push(nb);
+    palette = palette.filter(function (b) { return b.id !== block.id; });
+    selected = null;
+    // Tutorial advance: step 3 (drag a piece) clears as soon as the player
+    // places anything via drag.
+    if (tutorialMode && tutorialStep === 3) tutorialStep = 4;
+    // Kick snap animation from the drag-release position to the target cell.
+    if (fromX != null && fromY != null && L.cellSize) {
+      snapAnims.push({
+        id: nb.id,
+        fromX: fromX, fromY: fromY,
+        toX: L.boardX + cx * L.cellSize,
+        toY: L.boardY + cy * L.cellSize,
+        start: Date.now(),
+        shape: nb.shape,
+        color: nb.color,
+      });
+    }
+    try { wx.vibrateShort && wx.vibrateShort({ type: 'medium' }); } catch (e) {}
+    scene.dirty = true;
+    _tempSlot.markDirty(captureState());
+    checkWin();
+  }
+```
+
+If output differs, STOP and reconcile line numbers before continuing.
+
+- [ ] **Step 3: Insert the mismatch check just before `checkWin()`**
+
+Edit `calendar-puzzle-miniprogram/minigame/js/gameScene.js`.
+
+`old_string`:
+
+```js
+    try { wx.vibrateShort && wx.vibrateShort({ type: 'medium' }); } catch (e) {}
+    scene.dirty = true;
+    _tempSlot.markDirty(captureState());
+    checkWin();
+  }
+```
+
+`new_string`:
+
+```js
+    try { wx.vibrateShort && wx.vibrateShort({ type: 'medium' }); } catch (e) {}
+    scene.dirty = true;
+    _tempSlot.markDirty(captureState());
+    if (!hintState.mediumMismatchIgnored) {
+      var bCells = [];
+      for (var sy = 0; sy < nb.shape.length; sy++) {
+        for (var sx = 0; sx < nb.shape[sy].length; sx++) {
+          if (nb.shape[sy][sx] === 1) bCells.push({ x: nb.x + sx, y: nb.y + sy });
+        }
+      }
+      var mm = Hint.findMediumMismatch(hintState, nb.id, bCells);
+      if (mm) {
+        mediumMismatchModal = mm;
+        return;
+      }
+    }
+    checkWin();
+  }
+```
+
+- [ ] **Step 4: Smoke-test that the file still parses**
+
+Run: `node --check calendar-puzzle-miniprogram/minigame/js/gameScene.js`
+
+Expected: no output, exit code 0.
+
+- [ ] **Step 5: Confirm hint.js tests still pass (no regression)**
+
+Run: `cd calendar-puzzle-miniprogram && npm test 2>&1 | tail -6`
+
+Expected: `# pass NNN`, `# fail 0`. NNN is whatever the total is now (was 220 + 8 new = 228 after Tasks 1-3 complete).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/gameScene.js
+git commit -m "feat(minigame/hint): wire findMediumMismatch into placeBlock"
+```
+
+---
+
+## Task 5: gameScene — render the mismatch modal
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/gameScene.js` — add render block after the `staminaConfirm` render branch (around line 1265, the `else { L.staminaConfirmModal = null; ... }` block)
+
+- [ ] **Step 1: Confirm anchor — the line right after the staminaConfirm reset branch**
+
+Run: `sed -n '1259,1268p' calendar-puzzle-miniprogram/minigame/js/gameScene.js`
+
+Expected output (must match):
+
+```js
+    } else {
+      L.staminaConfirmModal = null;
+      L.staminaConfirmCheckbox = null;
+      L.staminaConfirmConvertBtn = null;
+      L.staminaConfirmNoBtn = null;
+      L.staminaConfirmYesBtn = null;
+    }
+
+    // --- 获取路径 二级 menu ---
+    if (sourceMenuOpen && L.sourceMenu) {
+```
+
+If different, STOP and reconcile.
+
+- [ ] **Step 2: Insert the mismatch-modal render block**
+
+Edit `calendar-puzzle-miniprogram/minigame/js/gameScene.js`.
+
+`old_string`:
+
+```js
+    } else {
+      L.staminaConfirmModal = null;
+      L.staminaConfirmCheckbox = null;
+      L.staminaConfirmConvertBtn = null;
+      L.staminaConfirmNoBtn = null;
+      L.staminaConfirmYesBtn = null;
+    }
+
+    // --- 获取路径 二级 menu ---
+```
+
+`new_string`:
+
+```js
+    } else {
+      L.staminaConfirmModal = null;
+      L.staminaConfirmCheckbox = null;
+      L.staminaConfirmConvertBtn = null;
+      L.staminaConfirmNoBtn = null;
+      L.staminaConfirmYesBtn = null;
+    }
+
+    // --- 中提示不一致弹窗 ---
+    if (mediumMismatchModal) {
+      R.overlay(ctx, W, H);
+      var mmW = Math.min(W * 0.78, 300), mmH = 200;
+      var mmX = (W - mmW) / 2, mmY = (H - mmH) / 2;
+      R.roundRect(ctx, mmX, mmY, mmW, mmH, 14, '#fff');
+
+      // Close (×) button — top right
+      var mmCloseR = 14;
+      var mmCloseX = mmX + mmW - mmCloseR - 12;
+      var mmCloseY = mmY + mmCloseR + 12;
+      R.roundRect(ctx, mmCloseX - mmCloseR, mmCloseY - mmCloseR, mmCloseR * 2, mmCloseR * 2, mmCloseR, '#f0f0f0');
+      R.textBold(ctx, '×', mmCloseX, mmCloseY, 16, '#666', 'center', 'middle');
+
+      R.textBold(ctx, '和中提示不一致', mmX + 20, mmY + 24, 15, '#333', 'left');
+
+      // Body — figure out which block(s) to draw + the prose around them.
+      // We need block shape + color from palette OR dropped (because the
+      // placed block has just been pushed into dropped).
+      var mmAllBlocks = palette.concat(dropped);
+      function _mmFindBlock(id) {
+        for (var i = 0; i < mmAllBlocks.length; i++) if (mmAllBlocks[i].id === id) return mmAllBlocks[i];
+        return null;
+      }
+      var mmKind = mediumMismatchModal.kind;
+      var mmPlacedId = mmKind === 'right-block-wrong-loc' ? mediumMismatchModal.blockId : mediumMismatchModal.placedBlockId;
+      var mmPlacedBlk = _mmFindBlock(mmPlacedId);
+      var mmHintedBlk = mmKind === 'wrong-block-on-hint' ? _mmFindBlock(mediumMismatchModal.hintedBlockId) : null;
+
+      // Draw a mini block-shape icon at (x, y), returning the width drawn.
+      function _mmDrawIcon(blk, x, y) {
+        if (!blk) return 0;
+        var cell = 7;
+        R.blockShape(ctx, blk.shape, blk.color, x, y, cell);
+        return blk.shape[0].length * cell;
+      }
+
+      var bodyY = mmY + 64;
+      var lineH = 22;
+      if (mmKind === 'right-block-wrong-loc') {
+        R.text(ctx, '你刚把', mmX + 20, bodyY, 13, '#555', 'left', 'middle');
+        var afterPrefix = mmX + 20 + 38;
+        var iconW = _mmDrawIcon(mmPlacedBlk, afterPrefix, bodyY - 10);
+        R.text(ctx, '放到了别的位置，', afterPrefix + iconW + 6, bodyY, 13, '#555', 'left', 'middle');
+        R.text(ctx, '但它的中提示还在等它。', mmX + 20, bodyY + lineH, 13, '#555', 'left', 'middle');
+      } else {
+        R.text(ctx, '你刚把', mmX + 20, bodyY, 13, '#555', 'left', 'middle');
+        var aP = mmX + 20 + 38;
+        var iw1 = _mmDrawIcon(mmPlacedBlk, aP, bodyY - 10);
+        R.text(ctx, '放到了', aP + iw1 + 6, bodyY, 13, '#555', 'left', 'middle');
+        var aP2 = aP + iw1 + 6 + 34;
+        var iw2 = _mmDrawIcon(mmHintedBlk, aP2, bodyY - 10);
+        R.text(ctx, '的中提示位置上。', aP2 + iw2 + 6, bodyY, 13, '#555', 'left', 'middle');
+      }
+
+      // Buttons
+      var mmBtnW = mmW - 40;
+      var mmTakeBackBtnH = 36;
+      var mmTakeBackY = mmY + mmH - mmTakeBackBtnH - 36;
+      R.button(ctx, mmX + 20, mmTakeBackY, mmBtnW, mmTakeBackBtnH, '取回并重新选中', '#43A047', '#fff', 8);
+
+      var mmIgnoreH = 20;
+      var mmIgnoreY = mmY + mmH - mmIgnoreH - 10;
+      R.text(ctx, '本局不再提示', mmX + mmW / 2, mmIgnoreY + mmIgnoreH / 2, 12, '#999', 'center', 'middle');
+
+      mediumMismatchLayoutCache = {
+        modal: { x: mmX, y: mmY, w: mmW, h: mmH },
+        closeBtn: { x: mmCloseX - mmCloseR, y: mmCloseY - mmCloseR, w: mmCloseR * 2, h: mmCloseR * 2 },
+        takeBackBtn: { x: mmX + 20, y: mmTakeBackY, w: mmBtnW, h: mmTakeBackBtnH },
+        ignoreBtn: { x: mmX + 20, y: mmIgnoreY, w: mmBtnW, h: mmIgnoreH + 4 },
+      };
+    } else {
+      mediumMismatchLayoutCache = null;
+    }
+
+    // --- 获取路径 二级 menu ---
+```
+
+- [ ] **Step 3: Smoke-test parsing**
+
+Run: `node --check calendar-puzzle-miniprogram/minigame/js/gameScene.js`
+
+Expected: no output, exit code 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/gameScene.js
+git commit -m "feat(minigame/hint): render medium-hint mismatch modal"
+```
+
+---
+
+## Task 6: gameScene — tap handler for the modal
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/js/gameScene.js:1972-1995` (`scene.onTouchEnd` opening)
+
+- [ ] **Step 1: Confirm the touch-end opening**
+
+Run: `sed -n '1972,1980p' calendar-puzzle-miniprogram/minigame/js/gameScene.js`
+
+Expected output (must match):
+
+```js
+  scene.onTouchEnd = function (x, y) {
+    // ── Save-slot modals: intercept ALL taps while a modal is open. ──
+    if (slotModal === 'save-picker' && slotPickerLayoutCache) {
+      var hit = slotUI.savePickerHitTest(x, y, slotPickerLayoutCache);
+      if (hit === 'cancel') {
+        slotModal = null; slotPickerLayoutCache = null;
+        scene.dirty = true;
+        return;
+      }
+```
+
+If different, STOP and reconcile.
+
+- [ ] **Step 2: Insert mismatch-modal handler at the very top of `onTouchEnd`**
+
+Edit `calendar-puzzle-miniprogram/minigame/js/gameScene.js`.
+
+`old_string`:
+
+```js
+  scene.onTouchEnd = function (x, y) {
+    // ── Save-slot modals: intercept ALL taps while a modal is open. ──
+    if (slotModal === 'save-picker' && slotPickerLayoutCache) {
+```
+
+`new_string`:
+
+```js
+  scene.onTouchEnd = function (x, y) {
+    // ── Medium-hint mismatch modal: intercept ALL taps while open. ──
+    if (mediumMismatchModal && mediumMismatchLayoutCache) {
+      var mmL = mediumMismatchLayoutCache;
+      // Take back: remove the offending placed block + re-select it in palette.
+      if (R.hitTest(x, y, mmL.takeBackBtn)) {
+        var mmPlacedId = mediumMismatchModal.kind === 'right-block-wrong-loc'
+          ? mediumMismatchModal.blockId
+          : mediumMismatchModal.placedBlockId;
+        removeDropped(mmPlacedId);
+        for (var pi = palette.length - 1; pi >= 0; pi--) {
+          if (palette[pi].id === mmPlacedId) { selected = palette[pi]; break; }
+        }
+        mediumMismatchModal = null;
+        mediumMismatchLayoutCache = null;
+        scene.dirty = true;
+        return;
+      }
+      // Ignore for the rest of this puzzle (persists across reload via hintState).
+      if (R.hitTest(x, y, mmL.ignoreBtn)) {
+        hintState = Hint.setMediumMismatchIgnored(hintState);
+        _tempSlot.markDirty(captureState());
+        mediumMismatchModal = null;
+        mediumMismatchLayoutCache = null;
+        scene.dirty = true;
+        return;
+      }
+      // Close — dismiss this instance only; next mismatch re-opens dialog.
+      if (R.hitTest(x, y, mmL.closeBtn)) {
+        mediumMismatchModal = null;
+        mediumMismatchLayoutCache = null;
+        scene.dirty = true;
+        return;
+      }
+      // Tap on dialog backdrop / anywhere else — swallow, no fall-through.
+      return;
+    }
+
+    // ── Save-slot modals: intercept ALL taps while a modal is open. ──
+    if (slotModal === 'save-picker' && slotPickerLayoutCache) {
+```
+
+- [ ] **Step 3: Smoke-test parsing**
+
+Run: `node --check calendar-puzzle-miniprogram/minigame/js/gameScene.js`
+
+Expected: no output, exit code 0.
+
+- [ ] **Step 4: Re-run the full test suite — no regression**
+
+Run: `cd calendar-puzzle-miniprogram && npm test 2>&1 | tail -6`
+
+Expected: all tests pass; `# fail 0`. Same total as after Task 4.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/js/gameScene.js
+git commit -m "feat(minigame/hint): tap handler for medium-hint mismatch modal"
+```
+
+---
+
+## Task 7: CHANGELOG entry
+
+**Files:**
+- Modify: `calendar-puzzle-miniprogram/minigame/CHANGELOG.md` — prepend a new `[0.6.0]` section above the current top entry (`[0.5.5]`).
+
+- [ ] **Step 1: Confirm CHANGELOG top**
+
+Run: `head -3 calendar-puzzle-miniprogram/minigame/CHANGELOG.md`
+
+Expected:
+
+```
+# Changelog
+
+## [0.5.5] — 2026-05-25
+```
+
+If `[0.5.5]` does not appear in the top entry (e.g., PR #10 has changed the version landed), STOP and ask user how to number the new entry.
+
+- [ ] **Step 2: Prepend the new entry**
+
+Edit `calendar-puzzle-miniprogram/minigame/CHANGELOG.md`.
+
+`old_string`:
+
+```
+# Changelog
+
+## [0.5.5] — 2026-05-25
+```
+
+`new_string`:
+
+```
+# Changelog
+
+## [0.6.0] — 2026-05-27
+
+> 中提示位置违规检测 — drop 后如果跟中提示对不上，弹个对话框让玩家立刻取回重选。
+
+### 改动一览
+
+- **中提示不一致对话框**：drop 后如果（a）刚放的方块占了别的方块的中提示位，或（b）刚放的方块是被中提示的那一块但没盖全提示位，弹一个白底圆角对话框。主按钮「取回并重新选中」一键撤回 + 自动选中那块；次级文字按钮「本局不再提示」整局闭嘴；右上角 × 仅关闭这次（下次再违规还弹）。
+- **跨重载**：「本局不再提示」状态搭车 `hintState.mediumMismatchIgnored` 走存档；同一道题恢复后继续闭嘴，换题或新开局自动重置。
+
+### 详情
+
+- `hint.js` 新增纯函数 `findMediumMismatch(state, blockId, blockCells)` + `setMediumMismatchIgnored(state)`，检测逻辑优先级：自己有中提示但没盖全 → `right-block-wrong-loc`；别的块的中提示位被占 → `wrong-block-on-hint`；都没命中返回 null。一次 drop 最多弹一次（找到第一个违规就返回）。
+- `gameScene.js` `placeBlock` 末尾、`checkWin` 之前插入检测调用；触发时模态层渲染对话框、tap handler 接管所有点击直到关闭。modal state 是 in-memory（`var mediumMismatchModal = null`），不参与存档；`hintState.mediumMismatchIgnored` 持久。
+- `restoreHintState` 兜底新字段：缺字段 → 默认 `false`，向后兼容历史存档。
+
+### 测试
+
+- `tests/hint.test.js` +8 用例：`createHintState` 字段默认值、`restoreHintState` round-trip（缺字段 + 有字段）、`findMediumMismatch` 全分支（null / right-block / wrong-block / 优先级）、`setMediumMismatchIgnored` 不可变性。
+- `npm test` → **228/228 pass**。
+- gameScene 模态渲染 + tap：无单元测试 harness，手测路径见下方。
+
+### 手测路径
+
+1. 任意题打开 → 用中提示在 A 块上揭一格 → 把 B 块（≠ A）拖到那一格 → 对话框弹出，文案带两个块的 mini-icon → 点「取回并重新选中」→ B 块回 palette 并自动选中。
+2. 同上揭 A 块一格 → A 块拖到别处（没盖到提示位）→ 对话框弹「你刚把 A 放到了别的位置」→ 关 × → 下次再这样放还弹。
+3. 同上揭 A 块一格 → B 块拖到提示位 → 点「本局不再提示」→ 之后再随便错放都不弹 → 退游戏 → 从存档恢复 → 错放还是不弹。换题或新开局后恢复弹。
+4. 教程模式 / 存档 `initialDropped` 自动放置不走 `placeBlock` → 不弹。
+
+## [0.5.5] — 2026-05-25
+```
+
+- [ ] **Step 3: Sanity check the prepend landed correctly**
+
+Run: `head -8 calendar-puzzle-miniprogram/minigame/CHANGELOG.md`
+
+Expected: first non-`# Changelog` heading is `## [0.6.0] — 2026-05-27`, and `## [0.5.5]` follows further down.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add calendar-puzzle-miniprogram/minigame/CHANGELOG.md
+git commit -m "docs(minigame): CHANGELOG 0.6.0 — medium-hint mismatch dialog"
+```
+
+---
+
+## Task 8: Manual WeChat-DevTools smoke + evidence
+
+`gameScene.js` is Canvas-rendered with no unit-test harness — verification is a manual walkthrough.
+
+**Files:**
+- Modify: `feature_list.json` — add entry for this feature
+- Optional: append a session record to `claude-progress.md` per repo handoff convention; overwrite `session-handoff.md` with current state.
+
+- [ ] **Step 1: Open `calendar-puzzle-miniprogram/` in WeChat DevTools (mini-game project type), hit Run**
+
+- [ ] **Step 2: Test Path 1 — wrong-block-on-hint, take back**
+
+Use a medium hint on block A (the L-block is convenient). On the popup, pick A. The board shows one orange-bordered hint cell.
+
+Pick block B (e.g., T-block) from palette. Drag it onto the orange hint cell. The modal opens. The body should read: `你刚把 [T-icon] 放到了 [L-icon] 的中提示位置上。`
+
+Tap **取回并重新选中**. Expected:
+- T-block disappears from board, reappears in palette.
+- T-block is auto-selected (preview row shows its shape; tap-to-place is armed).
+- Orange hint cell still visible for L-block.
+
+Screenshot the modal pre-tap and the post-tap state. Save under `feature_list.json` evidence path.
+
+- [ ] **Step 3: Test Path 2 — right-block-wrong-loc, × dismiss, re-fire**
+
+Drag block A (the L-block from path 1, still hinted) to ANY cell that does NOT cover the orange hint cell. Modal opens, body reads: `你刚把 [L-icon] 放到了别的位置，但它的中提示还在等它。`
+
+Tap the **×** at top-right. Modal closes. Block A stays where you dropped it.
+
+Drag block A elsewhere (still not covering hint). Modal **fires again**. This is the close-vs-ignore difference.
+
+Screenshot the modal + post-close state.
+
+- [ ] **Step 4: Test Path 3 — 本局不再提示 + reload persistence**
+
+From a fresh modal trigger, tap **本局不再提示**. Drop another contradicting block. Modal does NOT fire.
+
+Kill the mini-game from WeChat or hit the system back button to save → re-enter via "继续上次" / a named save slot. The same puzzle reloads. Drop another contradicting block. Modal **still** does not fire.
+
+Now random-switch the combo or back-to-menu and pick a new difficulty. Drop a contradicting block in the new puzzle. Modal fires (state was per-puzzle).
+
+Screenshot the pre- and post-reload behaviour.
+
+- [ ] **Step 5: Test Path 4 — no-hint baseline**
+
+Start a fresh puzzle. Do NOT use medium hint at all. Place blocks anywhere. Modal must NOT fire under any condition (covered by `mediumLocked` empty fast-path).
+
+- [ ] **Step 6: Update `feature_list.json` evidence**
+
+Add an entry for `medium-hint-mismatch-dialog`:
+- `status: passing`
+- Verification steps mirror Paths 1-4 above
+- Screenshot paths from Steps 2-3
+
+- [ ] **Step 7: Append session record + overwrite handoff**
+
+Per repo convention:
+- Prepend a new section to `claude-progress.md` under `## 会话记录` summarising this feature shipping
+- Overwrite `session-handoff.md` with current branch state, open PR, next steps
+
+- [ ] **Step 8: Commit evidence**
+
+```bash
+git add feature_list.json claude-progress.md session-handoff.md
+git commit -m "chore(minigame/hint): record evidence for medium-hint mismatch dialog"
+```
+
+(Skip files in this list that you did not modify.)
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:**
+  - Spec §Trigger → Task 4 (placeBlock wiring + bCells calc inline).
+  - Spec §Detection → Task 2 (`findMediumMismatch` + 5 tests covering all branches incl. priority).
+  - Spec §Suppression → Tasks 1, 3 (field + setter + round-trip tests).
+  - Spec §Dialog visual → Task 5 (modal render).
+  - Spec §Actions (take-back / ignore / close) → Task 6 (tap handler).
+  - Spec §State in gameScene → Task 4 (var decls), Task 5 (layout cache).
+  - Spec §Save-slot → Task 1 (round-trip line) + Task 6 (`markDirty` after ignore).
+  - Spec §Edge cases — no active hints / pre-feature slot / tutorial initialDropped / mid-mistake save / multi-violation → covered by detection short-circuits in Task 2, default-false restore in Task 1, the `if (!hintState.mediumMismatchIgnored)` guard in Task 4, and "first violation only" by `findMediumMismatch` returning early. The "block force-removed while dialog open" graceful degradation lives in Task 6's `removeDropped` defensive-no-op behaviour (existing).
+  - Spec §Testing — 8 cases — Task 1 (3) + Task 2 (5) + Task 3 (1) = 9. One bonus, fine.
+  - Spec §Files Touched / NOT Touched — Tasks 1-7 stay within the 4 declared files; `B.cellsOf` deliberately inlined into Task 4 per spec.
+
+- **No placeholders left.** Every code step has the full code; every verification step has the exact command + expected output.
+
+- **Type consistency:** `findMediumMismatch` return shape is `{ kind, blockId }` for `right-block-wrong-loc` and `{ kind, placedBlockId, hintedBlockId }` for `wrong-block-on-hint` — used consistently in Task 2 implementation, Task 4 trigger (no shape access, just sets the modal var), Task 5 render (reads `mediumMismatchModal.blockId` vs `.placedBlockId / .hintedBlockId`), and Task 6 tap handler (`mediumMismatchModal.blockId` vs `.placedBlockId`).

--- a/docs/superpowers/specs/2026-05-27-hardcore-mode-design.md
+++ b/docs/superpowers/specs/2026-05-27-hardcore-mode-design.md
@@ -1,0 +1,256 @@
+# 硬核模式（Hardcore Mode）设计
+
+- 日期：2026-05-27
+- 作用域：仅小游戏端 `calendar-puzzle-miniprogram/minigame/`（web `my-cal/` 与 Python 后端不动）
+- 基线分支：`feature/medium-hint-mismatch-dialog`（0.6.0 中提示不匹配弹窗合入后）
+- 实现分支建议：`feature/hardcore-mode`
+
+## 1. 需求摘要
+
+在 `selectScene` 难度选择界面，难度按钮下方加一个 `🔥 硬核模式` 开关（每局重选，不跨启动持久）。开关 ON 时，无论选择哪个底层难度（easy / medium / hard / expert / insomnia），进入游戏后：
+
+- **禁用**：提示按钮（弱 / 中 / 强全禁，按钮不渲染）；随机换题 🎲；选题 🎯。
+- **替换**：原"↺ 重开"按钮 → "🧹 清空"：清掉所有已落方块回 palette，**计时器不重置**。
+- **保留**：双击移除单个方块；错放即时反馈；分享得券（券池继续增长，留给非硬核局使用）。
+- **新增**：顶栏右上角 ☰ 暂停菜单（半屏 sheet），首发条目：`🔥 放弃硬核` / `🏠 返回首页` / 题面信息块。
+
+通关时：
+
+- 结算页加 "🔥 硬核通关" 文案行。
+- `progress` 记录 `hardcoreDays[dateStr][difficulty] = true`，幂等。
+
+存档：
+
+- 存档 payload 增加 `mode: { hardcore: bool }` 字段，round-trip。
+- 老存档无此字段时默认 `{ hardcore: false }`，向后兼容。
+- 恢复硬核存档时保留硬核状态，暂停菜单中可一键"放弃硬核"**单向降级**为普通局（本局不计入 hardcoreDays）。
+
+## 2. 架构
+
+### 2.1 Mode 抽象（新文件）
+
+`minigame/js/mode.js`（~30 行）：
+
+```js
+var DEFAULT_MODE = { hardcore: false };
+
+function createMode(opts) {
+  opts = opts || {};
+  return { hardcore: !!opts.hardcore };
+}
+
+function isHardcore(mode) { return !!(mode && mode.hardcore); }
+
+// Capability 助手 — 未来加模式只要在这里加键。
+function canUseHint(mode)    { return !isHardcore(mode); }
+function canSwapPuzzle(mode) { return !isHardcore(mode); }
+function canRestart(mode)    { return !isHardcore(mode); }   // 普通"重开"（重置计时器）
+function canClearBoard(mode) { return true; }                 // 任何模式都允许"清空"，硬核下作为"重开"的替代
+
+module.exports = { DEFAULT_MODE, createMode, isHardcore,
+                   canUseHint, canSwapPuzzle, canRestart, canClearBoard };
+```
+
+设计取舍：选用"容器对象 + capability 助手"，比裸 boolean `isHardcore` 多一层间接，但禁用规则散落点收敛到 4 个具名函数，未来加"限时""每日挑战"等模式只需扩 `createMode` + 加 capability，不必全局重命名。
+
+### 2.2 selectScene 入口 UI
+
+布局（5 个难度按钮 grid 之下）：
+
+```
+ ┌─────────────────────────────────┐
+ │  接水  泡咖啡  开个会  加班  失眠  │  ← 现有 5 难度按钮（不动）
+ └─────────────────────────────────┘
+
+      🔥 硬核模式     [   OFF  ●  ]
+      关闭提示・换题・券，重开变为清空棋盘
+```
+
+- 状态：`selectScene` 实例变量 `this.hardcoreOn = false`，**不读不写 storage**。
+- 点击开关 → flip + 重绘；点击难度按钮 → `wx.createGameScene({ difficulty, mode: createMode({ hardcore: this.hardcoreOn }) })`。
+- "今日 X 种" 的 insomnia 徽章不变（硬核结果不进 `insomniaUnique`）。
+- 视觉：开关一行 + 灰色小字一行，字号留给实现阶段定（参考现有难度卡片字号体系）。
+
+### 2.3 gameScene 内 gating（4 个改动点）
+
+| # | 位置 | 现状 | 硬核行为 |
+|---|---|---|---|
+| 1 | `gameScene.js:957` 提示按钮渲染 | `R.button(..., '💡 提示', ...)` | `canUseHint(mode) === false` → 不渲染 `L.hintBtn = null`；右侧按钮整体左移（沿用 insomnia 同款"少一个按钮"布局） |
+| 2 | `gameScene.js:2622` 提示按钮命中 | `if (L.hintBtn && R.hitTest...)` | `L.hintBtn` 为 null 时已被 if 防住，无需额外改 |
+| 3 | `gameScene.js:962` 随机换题按钮 + `:965` 选题按钮 | `R.button(..., '🎲 随机', ...)` / `'🎯 选题'` | `canSwapPuzzle(mode) === false` → 同上不渲染，命中点失效 |
+| 4 | `gameScene.js:958` 重开按钮 + `:2636` 命中 | `'↺ 重开'`，`showToast('已重开当前题')`，`puzzle.resetTimer()` | `canRestart(mode) === false` → 按钮文案改 `'🧹 清空'`；命中走新分支 `clearBoardKeepTimer()`：把 `dropped` 全部 push 回 palette、`puzzle.placed` 清空、`showToast('已清空棋盘')`、**不**调用 `puzzle.resetTimer()` |
+
+`createGameScene` 入参增加 `opts.mode`，实例属性 `this.mode = createMode(opts.mode)`；`captureState()` 拼 payload 时 `mode: this.mode`；scene init 时如有 `savedState.mode`，用它覆盖入参 mode（存档优先）。
+
+### 2.4 暂停菜单（新组件）
+
+入口：顶栏右上角 `☰` 图标按钮，点击弹半屏 sheet（盖住下半部分，点空白处关闭）。
+
+**首发条目**（按用户确认）：
+
+1. `🔥 放弃硬核` — **仅当 `isHardcore(mode) === true` 时显示**。点击 → 二次确认弹窗（"放弃后本局不再计入今日硬核通关，确定?"）→ 确定 → `this.mode = createMode({hardcore:false})` → 重绘控制行（提示/换题/重开重新出现）→ `captureState` 写盘 → `showToast('已切回普通模式')`。**单向**：之后该条目消失。
+2. `🏠 返回首页` — 等价 `backBtn` 行为。**保留**左上 `backBtn` 不删，提供双入口（左上肌肉记忆 + 菜单标准位）。
+3. **题面信息**（只读区块）：`2026-05-27 · 加班赶报告 · 🔥 硬核`（若非硬核则不显示 🔥 后缀）。
+
+**不在 MVP**：音效开关、关于、版本号、重玩教程 — 留给后续按需追加（暂停菜单是 sheet，加条目 = 加 1 行，未来无架构成本）。
+
+### 2.5 通关判定 & 进度记录
+
+`progress.js` 新增：
+
+```js
+function markHardcoreCleared(dateStr, difficulty) {
+  var rec = getRecord();
+  rec.hardcoreDays = rec.hardcoreDays || {};
+  var entry = rec.hardcoreDays[dateStr] = rec.hardcoreDays[dateStr] || {};
+  if (entry[difficulty]) return false;
+  entry[difficulty] = true;
+  putRecord(rec);
+  return true;  // first-time-today-at-this-difficulty
+}
+
+function hasHardcoreCleared(dateStr, difficulty) {
+  var rec = getRecord();
+  var entry = rec.hardcoreDays && rec.hardcoreDays[dateStr];
+  return !!(entry && entry[difficulty]);
+}
+```
+
+按日期 + 底层难度记录，符合"硬核可搭配任何难度"的语义，未来"今日硬核刷满 5 难度有奖励"无需 schema 演进。
+
+`gameScene` `puzzle.success` 路径（约 `gameScene.js:421` 附近 `insomniaUnique = ...` 处）增加：
+
+```js
+var hardcoreCleared = false;
+if (mode.isHardcore(this.mode)) {
+  hardcoreCleared = progress.markHardcoreCleared(puzzle.dateStr, difficulty);
+}
+// 传给 winStats，结算页根据 hardcoreCleared / mode 显示 "🔥 硬核通关"
+```
+
+注意：结算页文案只看本局 `mode.hardcore`（说明本局确实是硬核），不看 `markHardcoreCleared` 的返回值（false 表示今日同难度第二次以上通关，仍然是硬核局，文案仍要显示）。
+
+## 3. 数据流
+
+**新开局**：
+```
+selectScene.hardcoreOn=true
+  → 点 expert 按钮
+  → createGameScene({difficulty:'expert', mode: createMode({hardcore:true})})
+  → gameScene.this.mode = {hardcore:true}
+  → render 时 canUseHint(mode)=false → L.hintBtn=null
+  → canSwapPuzzle(mode)=false → 🎲/🎯 不渲染
+  → canRestart(mode)=false → 按钮文案 '🧹 清空'
+  → 顶栏 ☰ 渲染
+```
+
+**通关**：
+```
+puzzle.success 触发
+  → hardcoreCleared = progress.markHardcoreCleared('2026-05-27', 'expert')
+  → winStats.hardcore = true
+  → 结算页渲染 "🔥 硬核通关" 文案行
+```
+
+**退出 & 恢复**：
+```
+退出 → captureState() = {..., mode: {hardcore:true}} → tempSlot/named slot 落盘
+恢复 → scene init 读 savedState.mode → this.mode = createMode(savedState.mode)
+     → 控制行渲染同新开局；☰ 菜单中"放弃硬核"可见
+```
+
+**放弃硬核**：
+```
+☰ → 放弃硬核 → 二次确认 → this.mode = createMode({hardcore:false})
+  → 重绘控制行（4 按钮全回）→ captureState 写盘
+  → showToast('已切回普通模式')
+  → ☰ 菜单中"放弃硬核"条目消失
+后续 puzzle.success → mode.hardcore=false → 不调 markHardcoreCleared
+                  → 结算页无 "🔥 硬核通关"
+```
+
+## 4. 数据 schema
+
+### 4.1 存档 slot payload（演进）
+
+```js
+{
+  difficulty: 'expert',
+  puzzle: { dateStr, ... },
+  dropped: [...],
+  hintState: {...},        // 硬核局始终为 createHintState 初值（从不被填充）
+  playedCombos: {...},
+  mode: { hardcore: true } // 新字段，缺省时视作 { hardcore: false }
+}
+```
+
+### 4.2 progress 持久层
+
+```js
+{
+  // ... 现有字段
+  hardcoreDays: {
+    '2026-05-27': { easy: true, expert: true },
+    '2026-05-28': { hard: true },
+  }
+}
+```
+
+稀疏存储；首次通关写入；同日同难度第二次通关无副作用。
+
+## 5. 错误处理 & 兼容性
+
+- **老存档恢复**：`savedState.mode` 不存在 → `createMode(undefined)` → `{hardcore:false}`，与原有行为完全一致。
+- **老 progress 数据**：`rec.hardcoreDays` 不存在 → 首次 markHardcoreCleared 时懒创建。
+- **createGameScene 老调用**：未传 `opts.mode` → 视作 `{hardcore:false}`。
+- **硬核局意外触发提示路径**：在硬核下 hint 按钮不渲染，hintBtn 命中分支已被 `if (L.hintBtn && ...)` 守护。即使外部代码 bug 调到 `applyWeak/Medium/Strong`，hintState 会被更新但 UI 不响应——不构成数据腐蚀。
+- **券花费旁路**：当前 spend 路径只通过提示按钮触发；本期不在 `voucher.applyUsed` 加 hardcore 守护（YAGNI）。未来如出现"硬核局也能花券的别处路径"，再补一行 `if (isHardcore(currentMode)) throw ...`。记入 §8 未来工作。
+
+## 6. 测试
+
+### 6.1 单元测试
+
+| 文件 | 用例 |
+|---|---|
+| 新 `tests/mode.test.js` | `createMode()` 缺省 / 传 `{hardcore:true}`；`isHardcore` 两分支；4 个 capability 函数（硬核态 / 非硬核态）共 8 断言 |
+| 新 `tests/progress.hardcore.test.js`（仓库当前无 `progress.test.js`） | `markHardcoreCleared` 首次返回 true；同日同难度重复返回 false；同日不同难度并存；`hasHardcoreCleared` 三态读取；storage round-trip |
+| `tests/slotStore.test.js` | +1：`mode: {hardcore:true}` round-trip；+1：老 payload 无 `mode` 字段恢复后视作 `{hardcore:false}` |
+
+### 6.2 手测路径（真机 / 微信开发者工具）
+
+1. **开关入口** — selectScene 勾 🔥 → 选 expert → 进游戏 → 控制行只有 "🧹 清空" 一个按钮，无 💡 提示 / 🎲 随机 / 🎯 选题。
+2. **清空 vs 重开** — 硬核局放几个方块 → 点 "🧹 清空" → 棋盘空，方块回 palette，**顶栏/底栏计时器数字继续跑**（不归零）。
+3. **暂停菜单** — 顶栏右上 ☰ → sheet 弹出，含 `🔥 放弃硬核` / `🏠 返回首页` / 题面信息块；点空白处关闭。
+4. **放弃硬核** — ☰ → 放弃硬核 → 二次确认 → 确定 → 控制行恢复 4 按钮、☰ 菜单中"放弃硬核"消失、本局通关结算无 "🔥 硬核通关"、`progress.hardcoreDays` 不被写入。
+5. **存档恢复** — 硬核 expert 局玩 3 步 → 退出（含 0.5.5 自动占空名槽路径）→ 从槽恢复 → 控制行仍是 1 按钮、☰ 菜单中"放弃硬核"仍可见、题面 badge "🔥 硬核" 仍显示。
+6. **券与分享解耦** — 硬核局触发分享得券（若 0.6.0 流程允许在游戏内分享）→ 券数 +1；硬核局任何路径都无法花券。
+7. **通关记录** — 硬核 expert 通关 → 结算页 "🔥 硬核通关" 显示 → 检视 progress → `hardcoreDays['2026-05-27'].expert === true`。
+8. **0.6.0 中提示不匹配** — 硬核局放置任意方块，**不**弹出中提示不匹配 modal（因 `hintState.medium` 始终为 null）。
+
+## 7. 已知风险
+
+- **顶栏 ☰ 与 backBtn 视觉冲突**：`gameScene.js:617` 已占左上，新 ☰ 在右上，需确认 menuRect 安全区不挤压；实现时若发现冲突，优先收缩 ☰ 图标尺寸 / 调整 padding，**不**删 backBtn。
+- **存档 schema 升版**：本变更不需要迁移脚本，但要确保 `slotStore.test.js` 的"老 payload"用例真正走"无 mode 字段"路径。
+- **依赖分支**：基于未合 main 的 `feature/medium-hint-mismatch-dialog`。如该分支后续 force-push 或被 rebase，硬核分支需要相应处理。
+- **暂停菜单未做的副作用**：MVP 不含音效、关于、版本号 — 用户若期望"暂停菜单一上来就标配这些"，会有落差。spec 已明确范围，文档/CHANGELOG 也要说清"MVP 三条"。
+
+## 8. 未来工作（明确不在本次范围）
+
+- 券花费路径在 `voucher.applyUsed` 层加硬核守护（防御性，当前无入口可触发）。
+- 暂停菜单加：音效开关 / 重玩教程 / 关于+版本号 / 反馈入口。
+- 硬核连胜统计（连续 N 天通关硬核任意难度）。
+- 硬核刷满当日所有难度的成就 / 奖励。
+- web `my-cal/` 端的硬核（当前 web 无提示/券/存档概念，需先补齐这些再谈硬核）。
+
+## 9. 文件清单（实现阶段会动到的）
+
+- 新增 `minigame/js/mode.js`
+- 新增 `minigame/js/pauseMenu.js`（或并入 gameScene 内一个 namespace）
+- 改 `minigame/js/selectScene.js`：硬核开关 UI + 状态 + 传参
+- 改 `minigame/js/gameScene.js`：mode 属性 + 4 处控制行 gating + 顶栏 ☰ + clearBoardKeepTimer + 通关判定
+- 改 `minigame/js/progress.js`：`markHardcoreCleared` / `hasHardcoreCleared`
+- 改 `minigame/js/slotStore.js` schema（只是 payload 字段透传，不改 storage 接口）
+- 新增 `minigame/tests/mode.test.js`
+- 新增 `minigame/tests/progress.hardcore.test.js`（仓库当前无 `progress.test.js`，直接新建）
+- 改 `minigame/tests/slotStore.test.js`：+2 用例
+- 改 `minigame/CHANGELOG.md`：`[0.7.0] — 2026-05-27` 段

--- a/docs/superpowers/specs/2026-05-27-medium-hint-mismatch-dialog-design.md
+++ b/docs/superpowers/specs/2026-05-27-medium-hint-mismatch-dialog-design.md
@@ -1,0 +1,198 @@
+# Medium-Hint Mismatch Dialog — Design
+
+**Date:** 2026-05-27
+**Status:** Draft (pending review)
+**Surface:** WeChat mini-game (`calendar-puzzle-miniprogram/minigame/`)
+
+## Problem
+
+When the player uses a medium hint, `hintState.mediumLocked[blockId]` records the
+revealed cells and the board renders them as orange-bordered cells. Today,
+nothing stops the player from contradicting the hint:
+
+- **Scenario A — wrong block on hint cell.** They drop a different block (Y)
+  onto cells that were revealed for block X. The orange hint cells get partially
+  hidden under Y; X can no longer land there.
+- **Scenario B — right block, wrong location.** They drop block X itself but
+  not at the revealed cells. The hint cells stay visible and orphaned; X is
+  stuck somewhere it cannot complete the puzzle.
+
+The player has paid for the hint (stamina or a voucher) and now has a dead
+hint sitting on the board with no in-game indication that something is wrong.
+A toast was discussed and rejected — it is too transient for a player who has
+spent real currency on the hint.
+
+## Goal
+
+When a placement contradicts an active medium hint, surface a modal dialog
+that names the conflict, lets the player undo the placement in one tap, and
+lets them opt out of further dialogs for the rest of the puzzle attempt.
+
+## Non-Goals
+
+- Weak / strong hint mismatches. (Weak prevents rotate/flip via separate
+  affordance; strong-locked blocks already cannot be removed by double-tap.)
+- Preventing the placement itself. The drop completes; the dialog reacts.
+- Coaching the player toward the correct placement (no "drop here" arrow).
+  The orange hint cells already convey location.
+
+## Scope
+
+### Trigger
+
+Called at the end of `placeBlock(...)` in `gameScene.js`, before `checkWin()`,
+guarded by `!hintState.mediumMismatchIgnored`.
+
+### Detection — `Hint.findMediumMismatch(state, blockId, blockCells)`
+
+Pure function in `hint.js`. Returns the first violation in this priority:
+
+1. **Scenario B (right block wrong location)** — `mediumLocked[blockId]` exists
+   and non-empty, and `mediumLocked[blockId]` is NOT a subset of `blockCells`.
+   Returns `{ kind: 'right-block-wrong-loc', blockId }`.
+
+2. **Scenario A (wrong block on hint cell)** — for any `X ≠ blockId` with
+   non-empty `mediumLocked[X]`, the intersection `mediumLocked[X] ∩ blockCells`
+   is non-empty. Returns `{ kind: 'wrong-block-on-hint', placedBlockId: blockId, hintedBlockId: X }`.
+
+3. Returns `null` otherwise.
+
+Rationale for B-before-A: when a block has its own active hint, "you didn't
+cover your own hint" is the most direct framing. If B violates and also happens
+to cover another block's hint, B wins.
+
+Only one violation is reported per drop. Subsequent violations come into focus
+naturally as the player resolves the current one (or after they ignore the
+round).
+
+### Suppression — `hintState.mediumMismatchIgnored`
+
+New boolean field on `hintState`. Defaults to `false` from `createHintState`.
+Round-tripped by `restoreHintState` so the flag persists across save / reload.
+Resets naturally when `hintState` is recreated for a new puzzle (`createHintState`
+fires per `puzzleId`).
+
+New pure setter `Hint.setMediumMismatchIgnored(state) → newState` (immutable
+update via `Object.assign({}, state, { mediumMismatchIgnored: true })`).
+
+No getter — read the field directly.
+
+### Dialog
+
+Modal, rendered after `staminaConfirm` in the gameScene draw pipeline.
+Blocks every other tap target.
+
+**Visual:**
+- Black overlay `rgba(0,0,0,0.35)` over the entire canvas.
+- White rounded card centered, width matches the `staminaConfirm` card.
+- Round close button (×) at top-right, 22×22 light-gray.
+- Title: `"和中提示不一致"`.
+- Body, by `kind`:
+  - `right-block-wrong-loc`: `"你刚把 [B-icon] 放到了别的位置，但它的中提示还在等它。"`
+  - `wrong-block-on-hint`: `"你刚把 [B-icon] 放到了 [X-icon] 的中提示位置上。"`
+  - `[icon]` is an inline mini-rendering of the block's `shape` matrix at
+    ~7px per cell, in the block's color.
+- Primary button (`#43A047` green): `"取回并重新选中"`.
+- Text button (gray, smaller): `"本局不再提示"`.
+
+### Actions
+
+- **取回 (take back)**: `removeDropped(placedId)` already pops from `dropped`,
+  pushes a fresh clone onto `palette`, sets `selected = null`, and dirties
+  `_tempSlot`. The dialog handler then locates that newly-pushed clone in
+  `palette` (last entry with matching `id`) and assigns it to `selected` so
+  the player sees the take-back land in "selected" state. Close dialog.
+- **本局不再提示**: `hintState = Hint.setMediumMismatchIgnored(hintState)`.
+  Close dialog. `_tempSlot.markDirty(captureState())` so the new ignored
+  state lands in the save slot.
+- **× / close**: close dialog only. Do not write hintState. Next contradicting
+  drop will fire the dialog again.
+
+### State in gameScene
+
+```js
+var mediumMismatchModal = null;   // null | { kind, blockId? , placedBlockId?, hintedBlockId? }
+var mediumMismatchLayoutCache = null;
+```
+
+Layout cache follows the same pattern as `slotPickerLayoutCache` — computed
+on first render after the modal opens, cleared when modal closes.
+
+### Save-slot
+
+No changes to `captureState()` shape. `hintState.mediumMismatchIgnored`
+piggybacks on the existing `hintState` round-trip wired through
+`restoreHintState` (Bug #1 fix, 0.5.4).
+
+The transient `mediumMismatchModal` UI state is **not** persisted — if a
+player saves with the dialog open, they reload with the dialog closed and
+the placement still in `dropped`. That is the right behavior (a save mid-
+mistake should not lock the player into a modal across sessions).
+
+## Edge Cases
+
+- **No active medium hints.** `mediumLocked` empty → `findMediumMismatch`
+  returns `null` immediately. No dialog.
+- **Drop replays into a slot from before this feature shipped.** Saved
+  hintState has no `mediumMismatchIgnored` field. `restoreHintState`
+  defaults it to `false`. No migration needed.
+- **Block dropped via tutorial / initialDropped restore.** Those paths do
+  NOT call `placeBlock` — they push into `dropped[]` directly. Detection
+  is skipped, which matches intent (tutorial / restore is not a user mistake).
+- **Block placed, dialog opens, then player force-removes the block via
+  double-tap.** Existing `removeDropped` path. The dialog stays open
+  pointing at a now-absent block. Mitigation: the **取回** button calls
+  `removeDropped` defensively (no-op if already gone) and the **× / 本局
+  不再提示** paths simply close. Acceptable degraded state.
+- **Player wins despite the mismatch.** Impossible by board geometry — a
+  mismatched placement cannot lead to a valid solve covering the hinted
+  cells with the hinted block. `checkWin()` not being called on the mismatch
+  drop is therefore safe.
+- **Multi-violation drop.** Only the first violation per the priority
+  ordering is reported. Resolution unblocks the next.
+
+## Testing
+
+`tests/hint.test.js` additions, all against pure `findMediumMismatch` /
+`setMediumMismatchIgnored`:
+
+1. `mediumLocked` empty → returns `null`.
+2. Block has own hint, drop covers all hint cells → returns `null`.
+3. Block has own hint, drop misses one hint cell → returns
+   `right-block-wrong-loc` for that block.
+4. Block has no hint, drop covers another block's hint cell → returns
+   `wrong-block-on-hint` with `hintedBlockId` set.
+5. Block has own hint AND covers another's hint → returns
+   `right-block-wrong-loc` (priority order).
+6. `mediumMismatchIgnored` true is ignored by `findMediumMismatch` — caller's
+   responsibility to short-circuit. (Test that the field's mere presence does
+   not affect detection.)
+7. `setMediumMismatchIgnored` returns a new state with the flag set; original
+   state untouched (immutability).
+8. `restoreHintState` round-trips `mediumMismatchIgnored: true` from a saved
+   slot. `restoreHintState` defaults `mediumMismatchIgnored: false` when the
+   field is absent from saved data.
+
+`gameScene.js` UI integration is canvas-rendered and has no test harness —
+verification is manual through WeChat DevTools, recorded in
+`feature_list.json` evidence per the existing convention.
+
+## Files Touched
+
+- `calendar-puzzle-miniprogram/minigame/js/hint.js` — three new pieces:
+  `createHintState` adds `mediumMismatchIgnored: false`, `restoreHintState`
+  round-trips it, `findMediumMismatch` + `setMediumMismatchIgnored` added
+  and exported.
+- `calendar-puzzle-miniprogram/minigame/js/gameScene.js` — new modal state
+  variables, trigger call inside `placeBlock`, render block + tap handler.
+- `calendar-puzzle-miniprogram/tests/hint.test.js` — 8 new cases.
+- `calendar-puzzle-miniprogram/minigame/CHANGELOG.md` — new entry.
+
+## Files Explicitly NOT Touched
+
+- `block.js` — if `B.cellsOf` does not already exist, the helper goes into
+  `gameScene.js` (it's a 5-line iteration). Adding it to `block.js` would
+  pull in a separate refactor pass we don't want here.
+- `puzzleGenerator.js`, `solver.js`, `tempSlot.js`, `cloudClient.js` — no
+  cross-cutting changes.
+- Weak / strong hint paths — out of scope.


### PR DESCRIPTION
合并两个已就绪但未发的特性版本，36 commits / +3454 行 / +28 测试用例（225 → 253，全绿）。

## 0.7.0 — 硬核模式

一键关掉所有辅助（提示 / 换题 / 重开），换"全凭脑子"的专注挑战。可叠加在 5 档已有难度上；通关解锁 "🔥 硬核通关" 标识，按日期 + 难度记录战绩。

**Added**
- 硬核开关（`selectScene` 难度按钮下方一行，🔥 toggle，本地持久化）
- 游戏内暂停菜单（左下角 ☰，避开微信胶囊菜单，锚定 popover 不占半屏）。MVP 三条：`🔥 放弃硬核`（单向降级 + 二次确认）、`🏠 返回首页`、当前题面只读信息
- 通关结算页 "🔥 硬核通关" 标签
- 存档列表 🔥 badge（继续游戏 / 槽位选择 / 覆盖确认 / 未完成对局四处）
- `progress.hardcoreDays` 持久化每日每难度硬核通关记录
- 新 `mode.js` 模块 + capability helpers（`canUseHint` / `canSwapPuzzle` / `canRestart` / `canClearBoard`）

**Changed**
- 硬核局控制行折叠为单按钮 "🧹 清空"（替代 "↺ 重开"），**清空时计时器不重置**；提示 / 🎲 随机 / 🎯 选题不渲染
- 存档 slot payload 新增 `mode: { hardcore: bool }`，老存档无字段自动视作非硬核（向后兼容）
- `createGameScene` 入参 +1 位 `modeOpts`；`selectScene.onSelect(difficulty, savedState, modeOpts)`；main.js 三层透传

**Fixed**
- `gameScene.js` `padBottom` ReferenceError —— ☰ 按钮位置误引用了 `computeLayout` 内的局部变量，改用闭包 `safeInsets.bottom`

## 0.6.0 — 中提示位置违规检测

drop 后如果跟中提示对不上，弹个对话框让玩家立刻取回重选。

- **检测**：（a）刚放的方块占了别的方块的中提示位，或（b）刚放的方块是被中提示的那一块但没盖全提示位 → 弹模态对话框。主按钮「取回并重新选中」一键撤回 + 自动选中；次级「本局不再提示」整局闭嘴；× 仅关本次
- **跨重载**：「本局不再提示」搭车 `hintState.mediumMismatchIgnored` 走存档；同题恢复继续闭嘴，换题/新开局自动重置
- 新增 `findMediumMismatch` / `setMediumMismatchIgnored` 纯函数；`apply{Weak,Medium,Strong}` 全部转写新字段；`restoreHintState` 缺字段兜底 `false`（向后兼容）

## 测试
- `npm test` → **253/253 pass**（225 + 14 medium-hint 用例 + 7 mode 用例 + 5 hardcore 用例 + 2 slotStore round-trip）
- gameScene 模态渲染 + tap 没单测 harness，手测路径见 CHANGELOG

## 手测路径（真机 / 微信开发者工具）

### 硬核模式
- 见 `docs/superpowers/specs/2026-05-27-hardcore-mode-design.md` §6.2 (1-8)
- ☰ 在左下角不撞胶囊菜单 + popover 锚定 ☰ 上方弹出，点 ☰ 外任意位置关闭
- 存档列表硬核局难度后显示 🔥；老存档无后缀
- 硬核开关重启小游戏后保留上次 ON/OFF
- 硬核 expert 通关 → 结算页 "🔥 硬核通关" 不与时间行重叠

### 中提示错位弹窗
1. 中提示在 A 块上揭一格 → 把 B 块（≠A）拖到那一格 → 弹窗带两个块的 mini-icon → 点「取回并重新选中」→ B 回 palette 并自动选中
2. 中提示揭 A 一格 → A 拖到别处（没盖到提示位）→ 弹「你刚把 A 放到了别的位置」→ × 关 → 下次再这样放还弹
3. 中提示揭 A 一格 → B 拖到提示位 → 点「本局不再提示」→ 之后乱放不弹 → 退游戏 → 恢复 → 还是不弹；换题/新开局后恢复弹
4. 教程模式 / 存档 `initialDropped` 自动放置不走 `placeBlock` → 不弹

## 备注
- 本 PR 合后 `feature/medium-hint-mismatch-dialog` 分支变冗余（提交全在 hardcore 里），可一并删
- 已 merge 最新 main，0 冲突，包含 #12 share-snapshot grayscale + #13 win-modal android dismiss fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)